### PR TITLE
Fix build on macOS

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -38,6 +38,10 @@ elif [[ "$OSTYPE" == "darwin"* ]]; then
     STDLIB="libc++"
     LIB_LINK_FLAGS="-lc++ -lc++abi"
 
+    if [ -z "$SDKROOT" ]; then
+      export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+    fi
+
 else
     printf "${RED}Unsupported platform: ${OSTYPE}${RESET}\n"
     exit 1

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -275,7 +275,7 @@ function download_dependencies()
         download_and_install_gtest
     fi;
     
-    if [[ -e $DIR/third_party/lib/libxed.$LIB_EXT ]] ; then
+    if [[ -e $DIR/third_party/lib/libxed.$LIB_EXT || -e $DIR/third_party/lib/libxed.a ]] ; then
         notice "${BLUE}XED FOUND!"
     else
         download_and_extract_xed

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -210,7 +210,6 @@ function download_and_extract_xed()
     mkdir -p $DIR/third_party/include/intel
     cp -r $DIR/third_party/src/xed/kits/${XED_VERSION}/lib/* $DIR/third_party/lib
     cp -r $DIR/third_party/src/xed/kits/${XED_VERSION}/include/* $DIR/third_party/include/intel
-    fix_library xed
 }
 
 function create_directory_tree()


### PR DESCRIPTION
I tried running the bootstrap script on macOS but hit a few snags. These changes get me through to compiling Remill, but I get a lot of output like

```
E0728 21:58:21.001000 3291550656 Translator.cpp:467] Could not find lifted block for PC 4512489476
```