### PR TITLE
Handle Instruction::kCategoryInvalid.

### DIFF
--- a/remill/Arch/Runtime/HyperCall.h
+++ b/remill/Arch/Runtime/HyperCall.h
@@ -37,6 +37,9 @@ class AsyncHyperCall {
 
     kX86SysEnter,
     kX86SysExit,
+
+    // Invalid instruction.
+    kInvalidInstruction
   } __attribute__((packed));
 };
 

--- a/remill/Arch/X86/Runtime/Instructions.cpp
+++ b/remill/Arch/X86/Runtime/Instructions.cpp
@@ -123,10 +123,17 @@ DEF_SEM(HandleUnsupported) {
       memory, state, IF_64BIT_ELSE(SyncHyperCall::kAMD64EmulateInstruction,
                                    SyncHyperCall::kX86EmulateInstruction));
 }
+
+// Takes the place of an invalid instruction.
+DEF_SEM(HandleInvalidInstruction) {
+    HYPER_CALL = AsyncHyperCall::kInvalidInstruction;
+}
+
 }  // namespace
 
 // Takes the place of an unsupported instruction.
 DEF_ISEL(UNSUPPORTED_INSTRUCTION) = HandleUnsupported;
+DEF_ISEL(INVALID_INSTRUCTION) = HandleInvalidInstruction;
 
 #include "remill/Arch/X86/Semantics/FLAGS.cpp"
 #include "remill/Arch/X86/Semantics/BINARY.cpp"

--- a/remill/BC/Lifter.cpp
+++ b/remill/BC/Lifter.cpp
@@ -608,8 +608,7 @@ void Lifter::LiftTerminator(llvm::BasicBlock *block,
                                 const Instruction *arch_instr) {
   switch (arch_instr->category) {
     case Instruction::kCategoryInvalid:
-      LOG(FATAL)
-          << "Invalid instruction category.";
+      AddTerminatingTailCall(block, intrinsics->async_hyper_call);
       break;
 
     case Instruction::kCategoryNormal:
@@ -694,6 +693,11 @@ llvm::Function *GetInstructionFunction(llvm::Module *module,
 llvm::BasicBlock *Lifter::LiftInstruction(llvm::Function *block_func,
                                               Instruction *arch_instr) {
   auto isel_func = GetInstructionFunction(module, arch_instr->function);
+
+  if(arch_instr->category == Instruction::kCategoryInvalid) {
+    isel_func = GetInstructionFunction(module, "INVALID_INSTRUCTION");
+  }
+
   if (!isel_func) {
     LOG(ERROR)
         << "Cannot lift instruction at " << std::hex << arch_instr->pc << ", "


### PR DESCRIPTION
Add identifier `AsyncHyperCall::kInvalidInstruction` to HyperCall.h. Define the function `HandleInvalidInstruction` in Instructions.cpp and associate it with `INVALID_INSTRUCTION`. When the instruction category is `kCategoryInvalid` setup call to `INVALID_INSTRUCTION`.