### PR TITLE
ADRP and B instructions for AArch64

### DIFF
--- a/remill/Arch/AArch64/Arch.cpp
+++ b/remill/Arch/AArch64/Arch.cpp
@@ -295,7 +295,7 @@ static void AddImmOperand(Instruction &inst, uint64_t val,
   inst.operands.push_back(op);
 }
 
-static void AddPCRegOp(Instruction &inst, Operand::Action action, uint64_t disp, Operand::Address::Kind opKind) {
+static void AddPCRegOp(Instruction &inst, Operand::Action action, int64_t disp, Operand::Address::Kind opKind) {
   Operand op;
   op.type = Operand::kTypeAddress;
   op.size = 64;
@@ -309,7 +309,7 @@ static void AddPCRegOp(Instruction &inst, Operand::Action action, uint64_t disp,
 }
 
 // emit a memory read or write of [PC+disp]
-static void AddPCRegMemOp(Instruction &inst, Action action, uint64_t disp) {
+static void AddPCRegMemOp(Instruction &inst, Action action, int64_t disp) {
   if (kActionRead == action) {
       AddPCRegOp(inst, Operand::kActionRead, disp, Operand::Address::kMemoryRead);
   } else if (kActionWrite == action) {
@@ -321,7 +321,7 @@ static void AddPCRegMemOp(Instruction &inst, Action action, uint64_t disp) {
 }
 
 // emit an address operand that computes [PC + disp]
-static void AddPCDisp(Instruction &inst, uint64_t disp) {
+static void AddPCDisp(Instruction &inst, int64_t disp) {
   AddPCRegOp(inst,
           Operand::kActionRead, // This instruction reads $PC
           disp,
@@ -872,7 +872,10 @@ bool TryDecodeADRP_ONLY_PCRELADDR(const InstData &data, Instruction &inst) {
 
   // the label is shifted left with 12 bits of zero
   // and then added to $PC
-  AddPCDisp(inst, static_cast<uint64_t>(data.immhi_immlo.simm20) << 12ULL);
+  // TODO(artem): per conversation with pag, we may not need to shift 
+  //              this but instead leave it as-is since mcsema will take
+  //              care of dealing with the reference.
+  AddPCDisp(inst, static_cast<int64_t>(data.immhi_immlo.simm21) << 12ULL);
   return true;
 }
 

--- a/remill/Arch/AArch64/Arch.cpp
+++ b/remill/Arch/AArch64/Arch.cpp
@@ -876,6 +876,12 @@ bool TryDecodeADRP_ONLY_PCRELADDR(const InstData &data, Instruction &inst) {
   return true;
 }
 
+// B  <label>
+bool TryDecodeB_ONLY_BRANCH_IMM(const InstData &data, Instruction &inst) {
+  AddPCDisp(inst, static_cast<uint64_t>(data.imm26.simm26) << 4ULL);
+  return memory;
+}
+
 //static unsigned DecodeBitMasks(uint64_t N, uint64_t imms, uint64_t immr,
 //                               bool is_immediate) {
 //  uint64_t tmask = 0;

--- a/remill/Arch/AArch64/Arch.cpp
+++ b/remill/Arch/AArch64/Arch.cpp
@@ -872,7 +872,7 @@ bool TryDecodeADRP_ONLY_PCRELADDR(const InstData &data, Instruction &inst) {
 
   // the label is shifted left with 12 bits of zero
   // and then added to $PC
-  AddPCDisp(inst, static_cast<uint64_t>(data.imm19.simm20) << 12ULL);
+  AddPCDisp(inst, static_cast<uint64_t>(data.immhi_immlo.simm20) << 12ULL);
   return true;
 }
 

--- a/remill/Arch/AArch64/Arch.cpp
+++ b/remill/Arch/AArch64/Arch.cpp
@@ -295,18 +295,45 @@ static void AddImmOperand(Instruction &inst, uint64_t val,
   inst.operands.push_back(op);
 }
 
-static void AddNextPC(Instruction &inst) {
+static void AddPCRegOp(Instruction &inst, Operand::Action action, uint64_t disp, Operand::Address::Kind opKind) {
   Operand op;
   op.type = Operand::kTypeAddress;
   op.size = 64;
   op.addr.address_size = 64;
   op.addr.base_reg.name = "PC";
   op.addr.base_reg.size = 64;
-  op.addr.displacement = 4;
-
-  op.action = Operand::kActionRead;
-  op.addr.kind = Operand::Address::kAddressCalculation;
+  op.addr.displacement = disp;
+  op.addr.kind = opKind;
+  op.action = action;
   inst.operands.push_back(op);
+}
+
+// emit a memory read or write of [PC+disp]
+static void AddPCRegMemOp(Instruction &inst, Action action, uint64_t disp) {
+  if (kActionRead == action) {
+      AddPCRegOp(inst, Operand::kActionRead, disp, Operand::Address::kMemoryRead);
+  } else if (kActionWrite == action) {
+      AddPCRegOp(inst, Operand::kActionWrite, disp, Operand::Address::kMemoryWrite);
+  } else {
+    LOG(FATAL)
+        << __FUNCTION__ << " only accepts simple operand actions.";
+  }
+}
+
+// emit an address operand that computes [PC + disp]
+static void AddPCDisp(Instruction &inst, uint64_t disp) {
+  AddPCRegOp(inst,
+          Operand::kActionRead, // This instruction reads $PC
+          disp, // add +4 as the PC displacement
+          // emit an address computation operand
+          Operand::Address::kAddressCalculation
+  );
+}
+
+static void AddNextPC(Instruction &inst) {
+  // add +4 as the PC displacement
+  // emit an address computation operand
+  AddPCDisp(inst, 4);
 }
 
 // Base+offset memory operands are equivalent to indexing into an array.
@@ -587,27 +614,6 @@ bool TryDecodeLDR_64_LDST_POS(const InstData &data, Instruction &inst) {
   return true;
 }
 
-static void AddPCRegMemOp(Instruction &inst, Action action, uint64_t disp) {
-  Operand op;
-  op.type = Operand::kTypeAddress;
-  op.size = 64;
-  op.addr.address_size = 64;
-  op.addr.base_reg.name = "PC";
-  op.addr.base_reg.size = 64;
-  op.addr.displacement = disp;
-  if (kActionRead == action) {
-    op.action = Operand::kActionRead;
-    op.addr.kind = Operand::Address::kMemoryRead;
-  } else if (kActionWrite == action) {
-    op.action = Operand::kActionWrite;
-    op.addr.kind = Operand::Address::kMemoryWrite;
-  } else {
-    LOG(FATAL)
-        << "AddPCRegMemOp only accepts simple operand actions.";
-  }
-  inst.operands.push_back(op);
-}
-
 // LDR  <Wt>, <label>
 bool TryDecodeLDR_32_LOADLIT(const InstData &data, Instruction &inst) {
   AddRegOperand(inst, kActionWrite, kRegW, kUseAsValue, data.Rt);
@@ -856,6 +862,17 @@ bool TryDecodeMOVZ_64_MOVEWIDE(const InstData &data, Instruction &inst) {
   auto shift = static_cast<uint64_t>(data.hw) << 4U;
   AddRegOperand(inst, kActionWrite, kRegX, kUseAsValue, data.Rd);
   AddImmOperand(inst, (data.imm16.uimm << shift));
+  return true;
+}
+
+// ADRP  <Xd>, <label>
+bool TryDecodeADRP_ONLY_PCRELADDR(const InstData &data, Instruction &inst) {
+    // writes to a register
+  AddRegOperand(inst, kActionWrite, kRegX, kUseAsValue, data.Rd);
+
+  // the label is shifted left with 12 bits of zero
+  // and then added to $PC
+  AddPCDisp(inst, static_cast<uint64_t>(data.imm19.simm20) << 12ULL);
   return true;
 }
 

--- a/remill/Arch/AArch64/Decode.cpp
+++ b/remill/Arch/AArch64/Decode.cpp
@@ -41780,44 +41780,6 @@ bool TryDecodeUSHR_ASIMDSHF_R(const InstData &, Instruction &) {
   return false;
 }
 
-// B B_only_branch_imm:
-//   0 x imm26    0
-//   1 x imm26    1
-//   2 x imm26    2
-//   3 x imm26    3
-//   4 x imm26    4
-//   5 x imm26    5
-//   6 x imm26    6
-//   7 x imm26    7
-//   8 x imm26    8
-//   9 x imm26    9
-//  10 x imm26    10
-//  11 x imm26    11
-//  12 x imm26    12
-//  13 x imm26    13
-//  14 x imm26    14
-//  15 x imm26    15
-//  16 x imm26    16
-//  17 x imm26    17
-//  18 x imm26    18
-//  19 x imm26    19
-//  20 x imm26    20
-//  21 x imm26    21
-//  22 x imm26    22
-//  23 x imm26    23
-//  24 x imm26    24
-//  25 x imm26    25
-//  26 1
-//  27 0
-//  28 1
-//  29 0
-//  30 0
-//  31 0 op       0
-// B  <label>
-bool TryDecodeB_ONLY_BRANCH_IMM(const InstData &, Instruction &) {
-  return false;
-}
-
 // FCMEQ FCMEQ_asisdmiscfp16_FZ:
 //   0 x Rd       0
 //   1 x Rd       1

--- a/remill/Arch/AArch64/Decode.cpp
+++ b/remill/Arch/AArch64/Decode.cpp
@@ -49836,44 +49836,6 @@ bool TryDecodeLDRSH_64_LDST_REGOFF(const InstData &, Instruction &) {
   return false;
 }
 
-// ADRP ADRP_only_pcreladdr:
-//   0 x Rd       0
-//   1 x Rd       1
-//   2 x Rd       2
-//   3 x Rd       3
-//   4 x Rd       4
-//   5 x immhi    0
-//   6 x immhi    1
-//   7 x immhi    2
-//   8 x immhi    3
-//   9 x immhi    4
-//  10 x immhi    5
-//  11 x immhi    6
-//  12 x immhi    7
-//  13 x immhi    8
-//  14 x immhi    9
-//  15 x immhi    10
-//  16 x immhi    11
-//  17 x immhi    12
-//  18 x immhi    13
-//  19 x immhi    14
-//  20 x immhi    15
-//  21 x immhi    16
-//  22 x immhi    17
-//  23 x immhi    18
-//  24 0
-//  25 0
-//  26 0
-//  27 0
-//  28 1
-//  29 x immlo    0
-//  30 x immlo    1
-//  31 1 op       0
-// ADRP  <Xd>, <label>
-bool TryDecodeADRP_ONLY_PCRELADDR(const InstData &, Instruction &) {
-  return false;
-}
-
 // DUP DUP_asimdins_DR_r:
 //   0 x Rd       0
 //   1 x Rd       1

--- a/remill/Arch/AArch64/Semantics/BRANCH.cpp
+++ b/remill/Arch/AArch64/Semantics/BRANCH.cpp
@@ -124,6 +124,7 @@ DEF_SEM(CBNZ, R8W cond, S src, PC taken, PC not_taken) {
 }  // namespace
 
 DEF_ISEL(B_U) = DoDirectBranch;
+DEF_ISEL(B_ONLY_BRANCH_IMM) = DoDirectBranch;
 
 DEF_ISEL(B_LS_R8W_U_U) = DirectCondBranch<NotCond<CondHI>>;
 

--- a/remill/Arch/AArch64/Semantics/DATAXFER.cpp
+++ b/remill/Arch/AArch64/Semantics/DATAXFER.cpp
@@ -180,3 +180,20 @@ DEF_ISEL(MOV_ORR_64_LOG_SHIFT) = Load<R64W, R64>;
 
 DEF_ISEL(MOV_MOVZ_32_MOVEWIDE) = Load<R32W, I32>;
 DEF_ISEL(MOV_MOVZ_64_MOVEWIDE) = Load<R64W, I64>;
+
+
+namespace {
+
+DEF_SEM(LoadAddress64, R64W dst, PC label) {
+   addr_t label_addr = Read(label);
+
+   // clear the bottom 12 bits of label_addr
+   // to make this page aligned
+   // the Post decoding already made the label page aligned
+   // and added the label to PC
+   // the semantics just needs to fix up for PC not being page aligned
+   auto label_page = UAnd(UNot(4095), label_addr);
+   Write(dst, label_page);
+}
+
+DEF_ISEL(ADRP_only_pcreladdr) = LoadAddress64;

--- a/remill/Arch/AArch64/Semantics/DATAXFER.cpp
+++ b/remill/Arch/AArch64/Semantics/DATAXFER.cpp
@@ -192,8 +192,11 @@ DEF_SEM(LoadAddress64, R64W dst, PC label) {
    // the Post decoding already made the label page aligned
    // and added the label to PC
    // the semantics just needs to fix up for PC not being page aligned
-   auto label_page = UAnd(UNot(4095), label_addr);
+   auto label_page = UAnd(UNot(static_cast<uint64_t>(4095)), label_addr);
    Write(dst, label_page);
+   return memory;
 }
 
-DEF_ISEL(ADRP_only_pcreladdr) = LoadAddress64;
+} // namespace
+
+DEF_ISEL(ADRP_ONLY_PCRELADDR) = LoadAddress64;


### PR DESCRIPTION
* Support for `ADRP` (untested but translates)
* Support for PC-relative `B` (looks to work -- resolves targets during translation)