### PR TITLE
Adds in explicit tracking of the FPU control word into the State stru…

### DIFF
--- a/generated/Arch/X86/SaveState.S
+++ b/generated/Arch/X86/SaveState.S
@@ -1,5 +1,6 @@
 /* Auto-generated file! Don't modify! */
 
+fnstcw WORD PTR [RIP + STATE_PTR + 2688]
 #ifdef AFTER_TEST_CASE
 #if 64 == ADDRESS_SIZE_BITS
 fxsave64 [RIP + SYMBOL(gFPU)]

--- a/remill/Arch/X86/Runtime/State.h
+++ b/remill/Arch/X86/Runtime/State.h
@@ -372,8 +372,6 @@ union XCR0 {
 
 static_assert(8 == sizeof(XCR0), "Invalid packing of `XCR0`.");
 
-
-
 #if COMPILING_WITH_GCC
 using RequestPrivilegeLevel = uint16_t;
 using TableIndicator = uint16_t;
@@ -566,9 +564,11 @@ struct alignas(16) State final : public ArchState {
   MMX mmx;  // 128 bytes.
   FPUStatusFlags sw;  // 8 bytes
   XCR0 xcr0;  // 8 bytes.
+  FPUControlWord fpu_control;  // 2 bytes;
+  uint8_t _0[14];  // 14 bytes.
 } __attribute__((packed));
 
-static_assert((2672 + 16) == sizeof(State),
+static_assert((2688 + 16) == sizeof(State),
               "Invalid packing of `struct State`");
 
 using X86State = State;

--- a/remill/Arch/X86/Runtime/State.h
+++ b/remill/Arch/X86/Runtime/State.h
@@ -565,7 +565,7 @@ struct alignas(16) State final : public ArchState {
   FPUStatusFlags sw;  // 8 bytes
   XCR0 xcr0;  // 8 bytes.
   FPUControlWord fpu_control;  // 2 bytes;
-  uint8_t _0[14];  // 14 bytes.
+  uint8_t _padding[14];  // Pad to a 16-byte boundary.
 } __attribute__((packed));
 
 static_assert((2688 + 16) == sizeof(State),

--- a/remill/Arch/X86/Semantics/X87.cpp
+++ b/remill/Arch/X86/Semantics/X87.cpp
@@ -723,8 +723,8 @@ DEF_SEM(FNSTSW, D dst) {
 }
 
 DEF_SEM(FNSTCW, M16W dst) {
-  FPUControlWord cw = {};
-  cw.flat = 0x027F_u16;  // Our default, with double-precision.
+  auto &cw = state.fpu_control;
+  //cw.flat = 0x027F_u16;  // Our default, with double-precision.
   switch (fegetround()) {
     default:
     case FE_TONEAREST:
@@ -745,8 +745,9 @@ DEF_SEM(FNSTCW, M16W dst) {
 }
 
 DEF_SEM(FLDCW, M16 cwd) {
-  FPUControlWord cw = {};
+  auto &cw = state.fpu_control;
   cw.flat = Read(cwd);
+  cw.pc = kPrecisionSingle;
   int rounding_mode = FE_TONEAREST;
   switch (cw.rc) {
     case kFPURoundToNearestEven:
@@ -766,6 +767,7 @@ DEF_SEM(FLDCW, M16 cwd) {
       break;
   }
   fesetround(rounding_mode);
+
   return memory;
 }
 

--- a/tests/X86/PrintSaveState.cpp
+++ b/tests/X86/PrintSaveState.cpp
@@ -36,6 +36,9 @@ int main(void) {
 
   printf("/* Auto-generated file! Don't modify! */\n\n");
 
+  // Save the control word.
+  printf("fnstcw WORD PTR [RIP + STATE_PTR + %lu]\n", offsetof(State, fpu_control));
+
   // Save the native post-test FPU state.
   printf("#ifdef AFTER_TEST_CASE\n");
   printf("#if 64 == ADDRESS_SIZE_BITS\n");


### PR DESCRIPTION
…cture. This change helps make sure that VMill can initialize the FPU rounding modes correctly during its emulation. The AArch64 State struct already includes the fpcr.