### PR TITLE
Arch PKGBUILD: Change provides/conflicts to replaces

### DIFF
--- a/distro_packages/ArchLinux/PKGBUILD
+++ b/distro_packages/ArchLinux/PKGBUILD
@@ -10,8 +10,7 @@ license=('Apache')
 depends=('clang39' 'llvm39' 'llvm39-libs')
 makedepends=('git' 'curl' 'patchelf' 'cmake')
 
-provides=('remill')
-conflicts=('remill')
+replaces=('remill')
 
 source=("${pkgname}::git+https://github.com/trailofbits/remill.git")
 sha1sums=('SKIP')


### PR DESCRIPTION
This will allow you to update without manually uninstalling the old
package and installing the new one.