### PR TITLE
Arch PKGBUILD: Add replaces

### DIFF
--- a/distro_packages/ArchLinux/PKGBUILD
+++ b/distro_packages/ArchLinux/PKGBUILD
@@ -10,6 +10,7 @@ license=('Apache')
 depends=('clang39' 'llvm39' 'llvm39-libs')
 makedepends=('git' 'curl' 'patchelf' 'cmake')
 
+replaces=('remill')
 provides=('remill')
 conflicts=('remill')
 


### PR DESCRIPTION
This will upgrade people from `remill` to `remill-git` on system
upgrade.