### PR TITLE
Add X87 FBLD, FBSTP

### DIFF
--- a/remill/Arch/X86/Runtime/Operators.h
+++ b/remill/Arch/X86/Runtime/Operators.h
@@ -49,6 +49,39 @@ dec80_t _ReadDec80(Memory *memory, Mn<dec80_t> op) {
 
 #define ReadDec80(op) _ReadDec80(memory, op)
 
+ALWAYS_INLINE static
+Memory *_WriteDec80(Memory *memory, MD80W dst, dec80_t src) {
+  const auto num_digit_pairs = sizeof(src.digit_pairs);
+
+  _Pragma("unroll")
+  for (addr_t i = 0; i < num_digit_pairs; i++) {
+    memory = __remill_write_memory_8(memory, dst.addr + i, src.digit_pairs[i].u8);
+  }
+
+  uint8_t msb = static_cast<uint8_t>(src.is_negative << 7);
+  memory = __remill_write_memory_8(memory, dst.addr + num_digit_pairs, msb);
+
+  return memory;
+}
+
+#define WriteDec80(op, val) _WriteDec80(memory, op, val)
+
+ALWAYS_INLINE static
+Memory *_WriteDec80Indefinite(Memory *memory, MD80W dst) {
+  const uint8_t indefinite[sizeof(dec80_t)] = {
+    0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc0, 0xff, 0xff,
+  };
+
+  _Pragma("unroll")
+  for (addr_t i = 0; i < sizeof(indefinite); i++) {
+    memory = __remill_write_memory_8(memory, dst.addr + i, indefinite[i]);
+  }
+
+  return memory;
+}
+
+#define WriteDec80Indefinite(op) _WriteDec80Indefinite(memory, op)
+
 }  // namespace
 
 #endif  // REMILL_ARCH_X86_RUNTIME_OPERATORS_H_

--- a/remill/Arch/X86/Runtime/Operators.h
+++ b/remill/Arch/X86/Runtime/Operators.h
@@ -32,6 +32,23 @@ void _Write(Memory *, Reg &reg, IF_64BIT_ELSE(uint64_t, uint32_t) val) {
   reg.IF_64BIT_ELSE(qword, dword) = val;
 }
 
+ALWAYS_INLINE static
+dec80_t _ReadDec80(Memory *memory, Mn<dec80_t> op) {
+  dec80_t dec = {};
+  const auto num_digit_pairs = sizeof(dec.digits);
+
+  _Pragma("unroll")
+  for (addr_t i = 0; i < num_digit_pairs; i++) {
+    dec.digits[i] = __remill_read_memory_8(memory, op.addr + i);
+  }
+  auto msb = __remill_read_memory_8(memory, op.addr + num_digit_pairs);
+  dec.is_negative = msb >> 7;
+
+  return dec;
+}
+
+#define ReadDec80(op) _ReadDec80(memory, op)
+
 }  // namespace
 
 #endif  // REMILL_ARCH_X86_RUNTIME_OPERATORS_H_

--- a/remill/Arch/X86/Runtime/Operators.h
+++ b/remill/Arch/X86/Runtime/Operators.h
@@ -35,11 +35,11 @@ void _Write(Memory *, Reg &reg, IF_64BIT_ELSE(uint64_t, uint32_t) val) {
 ALWAYS_INLINE static
 dec80_t _ReadDec80(Memory *memory, Mn<dec80_t> op) {
   dec80_t dec = {};
-  const auto num_digit_pairs = sizeof(dec.digits);
+  const auto num_digit_pairs = sizeof(dec.digit_pairs);
 
   _Pragma("unroll")
   for (addr_t i = 0; i < num_digit_pairs; i++) {
-    dec.digits[i] = __remill_read_memory_8(memory, op.addr + i);
+    dec.digit_pairs[i].u8 = __remill_read_memory_8(memory, op.addr + i);
   }
   auto msb = __remill_read_memory_8(memory, op.addr + num_digit_pairs);
   dec.is_negative = msb >> 7;

--- a/remill/Arch/X86/Runtime/Operators.h
+++ b/remill/Arch/X86/Runtime/Operators.h
@@ -33,24 +33,24 @@ void _Write(Memory *, Reg &reg, IF_64BIT_ELSE(uint64_t, uint32_t) val) {
 }
 
 ALWAYS_INLINE static
-dec80_t _ReadDec80(Memory *memory, Mn<dec80_t> op) {
-  dec80_t dec = {};
-  const auto num_digit_pairs = sizeof(dec.digit_pairs);
+bcd80_t _ReadBCD80(Memory *memory, Mn<bcd80_t> op) {
+  bcd80_t bcd = {};
+  const auto num_digit_pairs = sizeof(bcd.digit_pairs);
 
   _Pragma("unroll")
   for (addr_t i = 0; i < num_digit_pairs; i++) {
-    dec.digit_pairs[i].u8 = __remill_read_memory_8(memory, op.addr + i);
+    bcd.digit_pairs[i].u8 = __remill_read_memory_8(memory, op.addr + i);
   }
   auto msb = __remill_read_memory_8(memory, op.addr + num_digit_pairs);
-  dec.is_negative = msb >> 7;
+  bcd.is_negative = msb >> 7;
 
-  return dec;
+  return bcd;
 }
 
-#define ReadDec80(op) _ReadDec80(memory, op)
+#define ReadBCD80(op) _ReadBCD80(memory, op)
 
 ALWAYS_INLINE static
-Memory *_WriteDec80(Memory *memory, MD80W dst, dec80_t src) {
+Memory *_WriteBCD80(Memory *memory, MBCD80W dst, bcd80_t src) {
   const auto num_digit_pairs = sizeof(src.digit_pairs);
 
   _Pragma("unroll")
@@ -64,11 +64,11 @@ Memory *_WriteDec80(Memory *memory, MD80W dst, dec80_t src) {
   return memory;
 }
 
-#define WriteDec80(op, val) _WriteDec80(memory, op, val)
+#define WriteBCD80(op, val) _WriteBCD80(memory, op, val)
 
 ALWAYS_INLINE static
-Memory *_WriteDec80Indefinite(Memory *memory, MD80W dst) {
-  const uint8_t indefinite[sizeof(dec80_t)] = {
+Memory *_WriteBCD80Indefinite(Memory *memory, MBCD80W dst) {
+  const uint8_t indefinite[sizeof(bcd80_t)] = {
     0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc0, 0xff, 0xff,
   };
 
@@ -80,7 +80,7 @@ Memory *_WriteDec80Indefinite(Memory *memory, MD80W dst) {
   return memory;
 }
 
-#define WriteDec80Indefinite(op) _WriteDec80Indefinite(memory, op)
+#define WriteBCD80Indefinite(op) _WriteBCD80Indefinite(memory, op)
 
 }  // namespace
 

--- a/remill/Arch/X86/Runtime/Types.h
+++ b/remill/Arch/X86/Runtime/Types.h
@@ -17,18 +17,18 @@
 #ifndef REMILL_ARCH_X86_RUNTIME_TYPES_H_
 #define REMILL_ARCH_X86_RUNTIME_TYPES_H_
 
-typedef union {
+union bcd_digit_pair_t {
   uint8_t u8;
   struct {
     uint8_t lsd:4;  // Least-significant digit
     uint8_t msd:4;  // Most-significant digit
   } __attribute((packed)) pair;
-} __attribute((packed)) bcd_digit_pair_t;
+} __attribute((packed));
 
 // TODO(joe): Assumes little endian.
 // 80-bit packed binary-coded decimal.
 struct bcd80_t final {
-  bcd_digit_pair_t digit_pairs[9];
+  union bcd_digit_pair_t digit_pairs[9];
   struct {
     uint8_t _unused:7;  // No meaning in encoding
     uint8_t is_negative:1;

--- a/remill/Arch/X86/Runtime/Types.h
+++ b/remill/Arch/X86/Runtime/Types.h
@@ -17,6 +17,18 @@
 #ifndef REMILL_ARCH_X86_RUNTIME_TYPES_H_
 #define REMILL_ARCH_X86_RUNTIME_TYPES_H_
 
+// TODO(joe): Assumes little endian.
+// 80-bit packed binary-coded decimal.
+struct dec80_t final {
+  uint8_t digits[9];
+  struct {
+    uint8_t _unused:7;  // No meaning in encoding
+    uint8_t is_negative:1;
+  } __attribute((packed));
+} __attribute__((packed));
+
+static_assert(10 == sizeof(dec80_t), "Invalid `dec80_t` size.");
+
 // What's going on with `R32W`? In 64-bit code, writes to the 32-bit general
 // purpose registers actually clear the high 32-bits of the associated 64-bit
 // registers, so we want to model that behavior.
@@ -67,6 +79,8 @@ typedef MnW<uint32_t> M32W;
 typedef MnW<uint64_t> M64W;
 typedef MnW<uint128_t> M128W;
 
+typedef MnW<dec80_t> MD80W;
+
 typedef MnW<float32_t> MF32W;
 typedef MnW<float64_t> MF64W;
 typedef MnW<float80_t> MF80W;
@@ -86,6 +100,8 @@ typedef Mn<uint16_t> M16;
 typedef Mn<uint32_t> M32;
 typedef Mn<uint64_t> M64;
 typedef Mn<uint128_t> M128;
+
+typedef Mn<dec80_t> MD80;
 
 typedef MVn<vec8_t> MV8;
 typedef MVn<vec16_t> MV16;

--- a/remill/Arch/X86/Runtime/Types.h
+++ b/remill/Arch/X86/Runtime/Types.h
@@ -17,16 +17,18 @@
 #ifndef REMILL_ARCH_X86_RUNTIME_TYPES_H_
 #define REMILL_ARCH_X86_RUNTIME_TYPES_H_
 
+typedef union {
+  uint8_t u8;
+  struct {
+    uint8_t lsd:4;  // Least-significant digit
+    uint8_t msd:4;  // Most-significant digit
+  } __attribute((packed)) pair;
+} __attribute((packed)) dec_digit_pair_t;
+
 // TODO(joe): Assumes little endian.
 // 80-bit packed binary-coded decimal.
 struct dec80_t final {
-  union {
-    uint8_t u8;
-    struct {
-      uint8_t lo:4;
-      uint8_t hi:4;
-    } __attribute((packed)) pair;
-  } __attribute((packed)) digit_pairs[9];
+  dec_digit_pair_t digit_pairs[9];
   struct {
     uint8_t _unused:7;  // No meaning in encoding
     uint8_t is_negative:1;

--- a/remill/Arch/X86/Runtime/Types.h
+++ b/remill/Arch/X86/Runtime/Types.h
@@ -20,7 +20,13 @@
 // TODO(joe): Assumes little endian.
 // 80-bit packed binary-coded decimal.
 struct dec80_t final {
-  uint8_t digits[9];
+  union {
+    uint8_t u8;
+    struct {
+      uint8_t lo:4;
+      uint8_t hi:4;
+    } __attribute((packed)) pair;
+  } __attribute((packed)) digit_pairs[9];
   struct {
     uint8_t _unused:7;  // No meaning in encoding
     uint8_t is_negative:1;

--- a/remill/Arch/X86/Runtime/Types.h
+++ b/remill/Arch/X86/Runtime/Types.h
@@ -23,19 +23,19 @@ typedef union {
     uint8_t lsd:4;  // Least-significant digit
     uint8_t msd:4;  // Most-significant digit
   } __attribute((packed)) pair;
-} __attribute((packed)) dec_digit_pair_t;
+} __attribute((packed)) bcd_digit_pair_t;
 
 // TODO(joe): Assumes little endian.
 // 80-bit packed binary-coded decimal.
-struct dec80_t final {
-  dec_digit_pair_t digit_pairs[9];
+struct bcd80_t final {
+  bcd_digit_pair_t digit_pairs[9];
   struct {
     uint8_t _unused:7;  // No meaning in encoding
     uint8_t is_negative:1;
   } __attribute((packed));
 } __attribute__((packed));
 
-static_assert(10 == sizeof(dec80_t), "Invalid `dec80_t` size.");
+static_assert(10 == sizeof(bcd80_t), "Invalid `bcd80_t` size.");
 
 // What's going on with `R32W`? In 64-bit code, writes to the 32-bit general
 // purpose registers actually clear the high 32-bits of the associated 64-bit
@@ -87,7 +87,7 @@ typedef MnW<uint32_t> M32W;
 typedef MnW<uint64_t> M64W;
 typedef MnW<uint128_t> M128W;
 
-typedef MnW<dec80_t> MD80W;
+typedef MnW<bcd80_t> MBCD80W;
 
 typedef MnW<float32_t> MF32W;
 typedef MnW<float64_t> MF64W;
@@ -109,7 +109,7 @@ typedef Mn<uint32_t> M32;
 typedef Mn<uint64_t> M64;
 typedef Mn<uint128_t> M128;
 
-typedef Mn<dec80_t> MD80;
+typedef Mn<bcd80_t> MBCD80;
 
 typedef MVn<vec8_t> MV8;
 typedef MVn<vec16_t> MV16;

--- a/remill/Arch/X86/Semantics/X87.cpp
+++ b/remill/Arch/X86/Semantics/X87.cpp
@@ -713,9 +713,9 @@ DEF_FPU_SEM(FBSTP, MD80W dst, RF80 src) {
   // Encode the double into packed BCD. By the range checks above, we know this
   // will succeed.
   for (uint64_t i = 0; i < sizeof(out_dec.digit_pairs); i++) {
-    out_dec.digit_pairs[i].pair.lo = static_cast<uint8_t>(casted % 10);
+    out_dec.digit_pairs[i].pair.lsd = static_cast<uint8_t>(casted % 10);
     casted /= 10;
-    out_dec.digit_pairs[i].pair.hi = static_cast<uint8_t>(casted % 10);
+    out_dec.digit_pairs[i].pair.msd = static_cast<uint8_t>(casted % 10);
     casted /= 10;
   }
 

--- a/remill/Arch/X86/Semantics/X87.cpp
+++ b/remill/Arch/X86/Semantics/X87.cpp
@@ -82,12 +82,12 @@ DEF_FPU_SEM(FBLD, RF80W, MD80 src1) {
 
   // Iterate through pairs of digits, encoded as bytes.
   _Pragma("unroll")
-  for (addr_t i = 0; i < sizeof(src1_dec.digits); i++) {
+  for (addr_t i = 0; i < sizeof(src1_dec.digit_pairs); i++) {
     // We expect each half-byte to be a valid binary-coded decimal
     // digit (0-9). If not, the decoding result is undefined. The
     // native behavior seems to continue as if each encoding were
     // valid, so we do the same.
-    auto b = src1_dec.digits[i];
+    auto b = src1_dec.digit_pairs[i].u8;
     auto lo = b & 0xf;
     auto hi = b >> 4;
 

--- a/tests/X86/Tests.S
+++ b/tests/X86/Tests.S
@@ -534,6 +534,7 @@ SYMBOL(__x86_test_table_begin):
 
 #include "tests/X86/X87/FADD.S"
 #include "tests/X86/X87/FBLD.S"
+#include "tests/X86/X87/FBSTP.S"
 #include "tests/X86/X87/FCMOV.S"
 #include "tests/X86/X87/FCOM.S"
 #include "tests/X86/X87/FDIV.S"

--- a/tests/X86/Tests.S
+++ b/tests/X86/Tests.S
@@ -533,6 +533,7 @@ SYMBOL(__x86_test_table_begin):
 #include "tests/X86/STRINGOP/STOS.S"
 
 #include "tests/X86/X87/FADD.S"
+#include "tests/X86/X87/FBLD.S"
 #include "tests/X86/X87/FCMOV.S"
 #include "tests/X86/X87/FCOM.S"
 #include "tests/X86/X87/FDIV.S"

--- a/tests/X86/X87/FBLD.S
+++ b/tests/X86/X87/FBLD.S
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+TEST_BEGIN_64(FBLD, 2)
+TEST_INPUTS(
+    0x0000, 0x0000000000000000,  // +0
+    0x8000, 0x0000000000000000,  // -0
+    0x0000, 0x0000000000000123,  //  123
+    0x8000, 0x0000000000000123,  // -123
+    0xff00, 0x0000000000000123,  // -123 with set don't-care bits
+    0x0012, 0x3456789123456789,  //  123456789123456789
+    0x8012, 0x3456789123456789,  // -123456789123456789
+    0x0000, 0x9007199254740993,  //  2^53 + 1, not representable as f64
+    0x0099, 0x9999999999999999,  //  10^18 - 1, max packed BCD
+    0x8099, 0x9999999999999999,  // -10^18 + 1, min packed BCD
+    0x00aa, 0xaaaaaaaaaaaaaaaa,  // Invalid packed BCD
+    0xffff, 0xffffffffffffffff)  // Invalid packed BCD, set high byte
+
+    push ARG1_64
+    push ARG2_64
+    fbld [rsp]
+TEST_END_64

--- a/tests/X86/X87/FBSTP.S
+++ b/tests/X86/X87/FBSTP.S
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2018 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+TEST_BEGIN_64(FBSTP, 1)
+TEST_INPUTS(
+    0x8000000000000000,  // -0
+    0x0000000000000000,  // 0
+    0xbfe0000000000000,  // -0.5
+    0x3fe0000000000000,  // 0.5
+    0x3fbf7ced916872b0,  // 0.123
+    0x3ff3ae147ae147ae,  // 1.23
+    0x405ec00000000000,  // 123
+    0xbfbf7ced916872b0,  // -0.123
+    0xbff3ae147ae147ae,  // -1.23
+    0xc05ec00000000000,  // -123
+    0x405edd2f1a9fbe77,  //  123.456
+    0xc05edd2f1a9fbe77,  // -123.456
+    0xc05ec00000000000,  // -123
+    0x405ec00000000000,  //  123
+    0xc3abc16d674ec800,  // -1e+18, min BCD value
+    0x43abc16d674ec800,  // 1e+18, max BCD value
+    // The below values are all invalid or out of BCD range.
+    0xfff8000000000001,  // -QNaN
+    0x7ff8000000000001,  //  QNaN
+    0xfff0000000000001,  // -SNan
+    0x7ff0000000000001,  //  SNan
+    0xfff0000000000000,  // -inf
+    0x7ff0000000000000,  //  inf
+    0xc3d158e460913d00,  // -2e+18
+    0x43d158e460913d00,  // 2e+18
+    0x433ffffffffffffe,  // 2^53 - 2, exactly representable as f64
+    0x433fffffffffffff,  // 2^53 - 1, max int exactly representable as f64
+    0x4340000000000000,  // 2^53, aliases 2^53 + 1
+    0xc33ffffffffffffe,  // -2^53 + 2, exactly representable as f64
+    0xc33fffffffffffff,  // -2^53 + 1, min int exactly representable as f64
+    0xc340000000000000)  // -2^53, aliases -2^53 - 1
+
+    push ARG1_64
+    fld QWORD PTR [rsp]
+
+    lea rsp, [rsp - 10]
+    fbstp [rsp]
+TEST_END_64

--- a/tests/X86/X87/FBSTP.S
+++ b/tests/X86/X87/FBSTP.S
@@ -18,22 +18,31 @@
 TEST_BEGIN_64(FBSTP, 1)
 TEST_INPUTS(
     0x8000000000000000,  // -0
-    0x0000000000000000,  // 0
-    0xbfe0000000000000,  // -0.5
-    0x3fe0000000000000,  // 0.5
-    0x3fbf7ced916872b0,  // 0.123
-    0x3ff3ae147ae147ae,  // 1.23
-    0x405ec00000000000,  // 123
+    0x0000000000000000,  //  0
+    0x3fbf7ced916872b0,  //  0.123
     0xbfbf7ced916872b0,  // -0.123
+    0xbfe0000000000000,  // -0.5
+    0x3fe0000000000000,  //  0.5
     0xbff3ae147ae147ae,  // -1.23
-    0xc05ec00000000000,  // -123
-    0x405edd2f1a9fbe77,  //  123.456
-    0xc05edd2f1a9fbe77,  // -123.456
+    0x3ff3ae147ae147ae,  //  1.23
     0xc05ec00000000000,  // -123
     0x405ec00000000000,  //  123
-    0xc3abc16d674ec800,  // -1e+18, min BCD value
-    0x43abc16d674ec800,  // 1e+18, max BCD value
+    0xc05edd2f1a9fbe77,  // -123.456
+    0x405edd2f1a9fbe77,  //  123.456
+    0xbffe666666666666,  // -1.9
+    0x3ffe666666666666,  //  1.9
+
+    // Min, max finite f64 values that are in BCD range,
+    // due to f64 floating-point aliasing.
+    0xc3abc16d674ec7ff,  // -1e+18 + 65
+    0x43abc16d674ec7ff,  //  1e+18 - 65
+
     // The below values are all invalid or out of BCD range.
+
+    // Minimum-magnitude finite f64 values that are out of range.
+    0xc3abc16d674ec800,  // -1e+18 + 64
+    0x43abc16d674ec800,  //  1e+18 - 64
+
     0xfff8000000000001,  // -QNaN
     0x7ff8000000000001,  //  QNaN
     0xfff0000000000001,  // -SNan
@@ -41,12 +50,12 @@ TEST_INPUTS(
     0xfff0000000000000,  // -inf
     0x7ff0000000000000,  //  inf
     0xc3d158e460913d00,  // -2e+18
-    0x43d158e460913d00,  // 2e+18
-    0x433ffffffffffffe,  // 2^53 - 2, exactly representable as f64
-    0x433fffffffffffff,  // 2^53 - 1, max int exactly representable as f64
-    0x4340000000000000,  // 2^53, aliases 2^53 + 1
+    0x43d158e460913d00,  //  2e+18
+    0x433ffffffffffffe,  //  2^53 - 2, exactly representable as f64
+    0x433fffffffffffff,  //  2^53 - 1, max contiguous int exactly representable as f64
+    0x4340000000000000,  //  2^53, aliases 2^53 + 1
     0xc33ffffffffffffe,  // -2^53 + 2, exactly representable as f64
-    0xc33fffffffffffff,  // -2^53 + 1, min int exactly representable as f64
+    0xc33fffffffffffff,  // -2^53 + 1, min contiguous int exactly representable as f64
     0xc340000000000000)  // -2^53, aliases -2^53 - 1
 
     push ARG1_64


### PR DESCRIPTION
For #45.

- [x] FBLD
- [x] FBSTP

The existing commits add the `fbld` instruction, whose semantic is given in terms of new types and operators for `mdec80` (80-bit packed BCD memory) operand types. If we're happy with that, then I'll go ahead and add `fbstp` next.