### PR TITLE
Important fix to semantics of LEA in the case of lea r32, [r64 ...], …

### DIFF
--- a/remill/Arch/X86/Arch.cpp
+++ b/remill/Arch/X86/Arch.cpp
@@ -261,7 +261,7 @@ std::map<xed_iform_enum_t, xed_iform_enum_t> kUnlockedIform = {
     {XED_IFORM_NEG_LOCK_MEMv, XED_IFORM_NEG_MEMv},
 };
 
-// Name of this instuction function.
+// Name of this instruction function.
 static std::string InstructionFunctionName(const xed_decoded_inst_t *xedd) {
 
   // If this instuction is marked as atomic via the `LOCK` prefix then we want
@@ -945,6 +945,8 @@ bool X86Arch::DecodeInstruction(
     DecodeConditionalInterrupt(inst);
   }
 
+  auto iform = xed_decoded_inst_get_iform_enum(xedd);
+
   if (!is_lazy || inst.IsControlFlow()) {
     inst.function = InstructionFunctionName(xedd);
 
@@ -970,7 +972,7 @@ bool X86Arch::DecodeInstruction(
         XED_CATEGORY_X87_ALU == xed_decoded_inst_get_category(xedd)) {
       auto set_ip_dp = false;
       const auto get_attr = xed_decoded_inst_get_attribute;
-      switch (xed_decoded_inst_get_iform_enum(xedd)) {
+      switch (iform) {
         case XED_IFORM_FNOP:
         case XED_IFORM_FINCSTP:
         case XED_IFORM_FDECSTP:
@@ -991,11 +993,17 @@ bool X86Arch::DecodeInstruction(
         DecodeX87LastIpDp(inst);
       }
     }
+
+    if (xed_decoded_inst_is_xacquire(xedd) ||
+        xed_decoded_inst_is_xrelease(xedd)) {
+      LOG(ERROR)
+          << "Ignoring XACQUIRE/XRELEASE prefix at " << std::hex
+          << inst.pc << std::dec;
+    }
   }
 
   // Make sure we disallow decoding of AVX instructions when running with non-
   // AVX arch specified. Same thing for AVX512 instructions.
-  auto iform = xed_decoded_inst_get_iform_enum(xedd);
   switch (xed_decoded_inst_get_isa_set(xedd)) {
     case XED_ISA_SET_INVALID:
     case XED_ISA_SET_LAST:

--- a/remill/Arch/X86/Semantics/MISC.cpp
+++ b/remill/Arch/X86/Semantics/MISC.cpp
@@ -19,9 +19,9 @@
 
 namespace {
 
-template <typename D, typename S>
+template <typename D, typename S, typename DestType>
 DEF_SEM(LEA, D dst, S src) {
-  WriteZExt(dst, AddressOf(src));
+  WriteZExt(dst, static_cast<DestType>(AddressOf(src)));
   return memory;
 }
 
@@ -48,8 +48,8 @@ DEF_SEM(LEAVE_FULL) {
 
 }  // namespace
 
-DEF_ISEL(LEA_GPRv_AGEN_32) = LEA<R32W, M8>;
-IF_64BIT( DEF_ISEL(LEA_GPRv_AGEN_64) = LEA<R64W, M8>; )
+DEF_ISEL(LEA_GPRv_AGEN_32) = LEA<R32W, M8, uint32_t>;
+IF_64BIT( DEF_ISEL(LEA_GPRv_AGEN_64) = LEA<R64W, M8, uint64_t>; )
 
 DEF_ISEL(LEAVE_16) = LEAVE_16BIT;
 DEF_ISEL_RI32or64(LEAVE, LEAVE_FULL);

--- a/remill/Arch/X86/Semantics/RTM.cpp
+++ b/remill/Arch/X86/Semantics/RTM.cpp
@@ -15,6 +15,8 @@
  */
 
 namespace {
+
+// Note: The taken branch is the transaction failed fallback path.
 DEF_SEM(XBEGIN, R8W cond, PC taken, PC not_taken) {
   Write(cond, true);
   Write(REG_PC, Read(taken));


### PR DESCRIPTION
…where the resulting address computation wasn't truncated to 32-bits before being written into the destination register. This bug manifested in the case where -1 (0xffffffff) was added to line_size (0x400) in libreadline, getting us 0x1000003ff, and only 0x3ff should have been written to an emulated register, but the complete 64-bit value was written instead, leading to a later buffer overflow (due in part to this integer overflow). The RTM stuff wasn't really at issue, but I had played around with their semantics while debugging something else.