### PR TITLE
Improve modeling of X87 exception and NaN handling

### DIFF
--- a/remill/Arch/X86/Semantics/FLAGS.cpp
+++ b/remill/Arch/X86/Semantics/FLAGS.cpp
@@ -202,12 +202,13 @@ struct Carry<tag_sub> {
     } while (false)
 
 
+// X87 status flags are sticky, so we must not unset flags if set.
 ALWAYS_INLINE static void SetFPSRStatusFlags(State &state, int mask) {
-  state.sw.pe = static_cast<uint8_t>(0 != (mask & FE_INEXACT));
-  state.sw.oe = static_cast<uint8_t>(0 != (mask & FE_OVERFLOW));
-  state.sw.ue = static_cast<uint8_t>(0 != (mask & FE_UNDERFLOW));
-  state.sw.ie = static_cast<uint8_t>(0 != (mask & FE_INVALID));
-  state.sw.ze = static_cast<uint8_t>(0 != (mask & FE_DIVBYZERO));
+  state.sw.pe |= static_cast<uint8_t>(0 != (mask & FE_INEXACT));
+  state.sw.oe |= static_cast<uint8_t>(0 != (mask & FE_OVERFLOW));
+  state.sw.ue |= static_cast<uint8_t>(0 != (mask & FE_UNDERFLOW));
+  state.sw.ie |= static_cast<uint8_t>(0 != (mask & FE_INVALID));
+  state.sw.ze |= static_cast<uint8_t>(0 != (mask & FE_DIVBYZERO));
 }
 
 template <typename F, typename T>

--- a/tests/X86/X87/MISC.S
+++ b/tests/X86/X87/MISC.S
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+#define SNAN_32 0x7fbfffff
+#define SNAN_64 0x7ff0000000000001
+
+#define QNAN_32 0x7fffffff
+#define QNAN_64 0x7ff8000000000001
+
+
 TEST_BEGIN(FNOP, 1)
 TEST_INPUTS(0)
     fnop
@@ -42,6 +49,8 @@ TEST_END
 
 TEST_BEGIN_64(FABS, 1)
 TEST_INPUTS(
+    QNAN_64,
+    SNAN_64,
     0x7ff0000000000000,  /* +inf */
     0xfff0000000000000,  /* -inf */
     0x3fe0000000000000,  /* 0.5 */
@@ -54,6 +63,8 @@ TEST_END_64
 
 TEST_BEGIN_64(FCHS, 1)
 TEST_INPUTS(
+    QNAN_64,
+    SNAN_64,
     0x7ff0000000000000,  /* +inf */
     0xfff0000000000000,  /* -inf */
     0x3fe0000000000000,  /* 0.5 */
@@ -66,6 +77,8 @@ TEST_END_64
 
 TEST_BEGIN_64(FCOS, 1)
 TEST_INPUTS(
+    QNAN_64,
+    SNAN_64,
     0x4058ff5c28f5c28f,  /* 99.99 */
     0xc058ff5c28f5c28f  /* -99.99 */)
 
@@ -76,6 +89,8 @@ TEST_END_64
 
 TEST_BEGIN_64(FSIN, 1)
 TEST_INPUTS(
+    QNAN_64,
+    SNAN_64,
     0x4058ff5c28f5c28f,  /* 99.99 */
     0xc058ff5c28f5c28f  /* -99.99 */)
 
@@ -86,6 +101,8 @@ TEST_END_64
 
 TEST_BEGIN_64(FSINCOS, 1)
 TEST_INPUTS(
+    QNAN_64,
+    SNAN_64,
     0x4058ff5c28f5c28f,  /* 99.99 */
     0xc058ff5c28f5c28f  /* -99.99 */)
 
@@ -96,6 +113,8 @@ TEST_END_64
 
 TEST_BEGIN_64(FSCALE, 1)
 TEST_INPUTS(
+    QNAN_64,
+    SNAN_64,
     0x401199999999999a,  /* 4.4 */
     0x4012000000000000,  /* 4.5 */
     0x4012666666666666,  /* 4.6 */
@@ -111,6 +130,8 @@ TEST_END_64
 
 TEST_BEGIN_64(FPREM, 2)
 TEST_INPUTS(
+    QNAN_64,
+    SNAN_64,
     0x4058ff5c28f5c28f, /* 99.99 */ 0x401199999999999a,  /* 4.4 */
     0x4058ff5c28f5c28f, /* 99.99 */ 0xc01199999999999a,  /* -4.4 */
     0xc058ff5c28f5c28f, /* -99.99 */ 0x401199999999999a,  /* 4.4 */
@@ -125,6 +146,8 @@ TEST_END_64
 
 TEST_BEGIN_64(FPREM1, 2)
 TEST_INPUTS(
+    QNAN_64,
+    SNAN_64,
     0x4058ff5c28f5c28f, /* 99.99 */ 0x401199999999999a,  /* 4.4 */
     0x4058ff5c28f5c28f, /* 99.99 */ 0xc01199999999999a,  /* -4.4 */
     0xc058ff5c28f5c28f, /* -99.99 */ 0x401199999999999a,  /* 4.4 */
@@ -139,6 +162,8 @@ TEST_END_64
 
 TEST_BEGIN_64(F2XM1, 1)
 TEST_INPUTS(
+    QNAN_64,
+    SNAN_64,
     0x3fe0000000000000,  /* 0.5 */
     0xbfe0000000000000  /* -0.5 */)
 
@@ -147,12 +172,14 @@ TEST_INPUTS(
     f2xm1
 TEST_END_64
 
+// TODO(joe): Test NaN handling.
 TEST_BEGIN(FPTAN, 1)
 TEST_INPUTS(0)
     fldl2e
     fptan
 TEST_END
 
+// TODO(joe): Test NaN handling.
 TEST_BEGIN(FPATAN, 1)
 TEST_INPUTS(0)
     fldl2e
@@ -162,6 +189,8 @@ TEST_END
 
 TEST_BEGIN_64(FSQRT, 1)
 TEST_INPUTS(
+    QNAN_32,
+    SNAN_32,
     0x41100000,   /* 9.0, a "perfect square," of which sqrt() is an integer */
     0x00000000,   /* sqrt(0) should be 0 */
     0x412E3D71,   /* 10.89, should return 3.33 */
@@ -178,6 +207,7 @@ TEST_INPUTS(
     fsqrt
 TEST_END_64
 
+// TODO(joe): Test NaN handling.
 TEST_BEGIN(FDECSTP, 1)
 TEST_INPUTS(0)
     fldl2e
@@ -185,6 +215,7 @@ TEST_INPUTS(0)
     fdecstp
 TEST_END
 
+// TODO(joe): Test NaN handling.
 TEST_BEGIN(FINCSTP, 1)
 TEST_INPUTS(0)
     fldl2e
@@ -201,6 +232,8 @@ TEST_END
 
 TEST_BEGIN_64(FXAM, 1)
 TEST_INPUTS(
+    QNAN_64,
+    SNAN_64,
     0x7ff0000000000000,  /* +inf */
     0xfff0000000000000,  /* -inf */
     0xfff8000000000000,  /* -nan */
@@ -217,6 +250,8 @@ TEST_END_64
 
 TEST_BEGIN_64(FTST, 1)
 TEST_INPUTS(
+    QNAN_64,
+    SNAN_64,
     0x7ff0000000000000,  /* +inf */
     0xfff0000000000000,  /* -inf */
     0xfff8000000000000,  /* -nan */
@@ -237,6 +272,8 @@ TEST_END_64
 
 TEST_BEGIN_64(FRNDINT, 1)
 TEST_INPUTS(
+    QNAN_64,
+    SNAN_64,
     0x401199999999999a,  /* 4.4 */
     0x4012000000000000,  /* 4.5 */
     0x4012666666666666,  /* 4.6 */
@@ -249,6 +286,7 @@ TEST_INPUTS(
     frndint
 TEST_END_64
 
+// TODO(joe): Test NaN handling.
 TEST_BEGIN(FY2LX, 1)
 TEST_INPUTS(0)
     fldpi
@@ -256,6 +294,7 @@ TEST_INPUTS(0)
     fyl2x
 TEST_END
 
+// TODO(joe): Test NaN handling.
 TEST_BEGIN(FY2LXP1, 1)
 TEST_INPUTS(0)
     fldpi


### PR DESCRIPTION
For #223.

- [x] Add NaN test inputs to surface inaccurate modeling
- [x] Ensure X87 exceptions flags are sticky
- [x] Ensure SNaNs are quietized before pushing onto X87 stack