### PR TITLE
Split PrepareModule into two functions

### DIFF
--- a/remill/Arch/Arch.cpp
+++ b/remill/Arch/Arch.cpp
@@ -321,9 +321,9 @@ static void InitBlockFunctionAttributes(llvm::Function *block_func) {
 
 }  // namespace
 
-// Converts an LLVM module object to have the right triple / data layout
-// information for the target architecture.
-void Arch::PrepareModule(llvm::Module *mod) const {
+// ensures that mandatory remill functions have the correct
+// type signature and variable names
+static void PrepareModuleRemillFunctions(llvm::Module *mod) {
   auto basic_block = BasicBlockFunction(mod);
 
   InitFunctionAttributes(basic_block);
@@ -335,7 +335,12 @@ void Arch::PrepareModule(llvm::Module *mod) const {
   basic_block->removeFnAttr(llvm::Attribute::InlineHint);
   basic_block->addFnAttr(llvm::Attribute::NoInline);
   basic_block->setVisibility(llvm::GlobalValue::DefaultVisibility);
+}
 
+// Converts an LLVM module object to have the right triple / data layout
+// information for the target architecture.
+//
+void Arch::PrepareModuleDataLayout(llvm::Module *mod) const {
   mod->setDataLayout(DataLayout().getStringRepresentation());
   mod->setTargetTriple(Triple().str());
 
@@ -366,6 +371,11 @@ void Arch::PrepareModule(llvm::Module *mod) const {
         target_attribs);
     func.setAttributes(attribs);
   }
+}
+
+void Arch::PrepareModule(llvm::Module *mod) const {
+    PrepareModuleRemillFunctions(mod);
+    PrepareModuleDataLayout(mod);
 }
 
 }  // namespace remill

--- a/remill/Arch/Arch.h
+++ b/remill/Arch/Arch.h
@@ -48,11 +48,20 @@ class Arch {
   static const Arch *Get(OSName os, ArchName arch_name);
 
   // Converts an LLVM module object to have the right triple / data layout
-  // information for the target architecture.
+  // information for the target architecture and ensures remill requied functions
+  // have the appropriate prototype and internal variables
   void PrepareModule(llvm::Module *mod) const;
 
   inline void PrepareModule(const std::unique_ptr<llvm::Module> &mod) const {
     PrepareModule(mod.get());
+  }
+
+  // Converts an LLVM module object to have the right triple / data layout
+  // information for the target architecture
+  void PrepareModuleDataLayout(llvm::Module *mod) const;
+
+  inline void PrepareModuleDataLayout(const std::unique_ptr<llvm::Module> &mod) const {
+    PrepareModuleDataLayout(mod.get());
   }
 
   // Decode an instruction.


### PR DESCRIPTION
* One function prepares __remill_block
* One function prepares the module's data layout

This is needed because mcsema's --abi_library flag needs to import
bitcode modules that do not have a __remill_block function defined