### PR TITLE
Work around glibc's fesetenv bugs

### DIFF
--- a/tests/X86/Run.cpp
+++ b/tests/X86/Run.cpp
@@ -489,16 +489,21 @@ static void ResetFlags(void) {
 
 // clear the exception flags in mxcsr
 // *and* set MXCSR to ignore denormal exceptions
-// this is done by newer (after 2015) glibcs
-// but is missing in older versions
+// this is done properly by std::fesetenv(FE_DFL_ENV) in newer (after 2015) glibcs
+// but the logic in older versions (like eglibc 2.19, used on some Ubuntu 14.04 installations)
+// does not clear exception flags and also does *not* ignore denormal exceptions
 // see: https://sourceware.org/ml/libc-alpha/2015-10/msg01020.html
 static void FixGlibcMxcsrBug() {
   const uint32_t FE_ALL_EXCEPT_X86 = (FE_ALL_EXCEPT | __FE_DENORM);
-  uint32_t mxcsr = 0; // temporary holds our mxcsr
+  uint32_t mxcsr = 0; // temporarily holds our MXCSR
   asm("stmxcsr %0;" : "=m"(mxcsr));
-  // assumes the rest of MXCSR was santely set by fesetenv
+  // assumes the rest of MXCSR was sanely set by std::fesetenv(FE_DFL_ENV);
+
+  // clear exceptions in MXCSR
   mxcsr &= ~FE_ALL_EXCEPT_X86;
+  // set the exception mask for future exceptions
   mxcsr |= (FE_ALL_EXCEPT_X86 << 7);
+
   asm("ldmxcsr %0;" : : "m"(mxcsr));
 }
 


### PR DESCRIPTION
Set the mxcsr manually to clear exceptions and ignore denormals.
Some older glibc versions do not do this, and it causes havok in our lifted code.

Another fix for now closed #187 since that issue re-appeared.