### PR TITLE
Set state and memory parameter attribute as noalias

### DIFF
--- a/remill/Arch/Arch.cpp
+++ b/remill/Arch/Arch.cpp
@@ -335,6 +335,9 @@ static void PrepareModuleRemillFunctions(llvm::Module *mod) {
   basic_block->removeFnAttr(llvm::Attribute::InlineHint);
   basic_block->addFnAttr(llvm::Attribute::NoInline);
   basic_block->setVisibility(llvm::GlobalValue::DefaultVisibility);
+
+  remill::NthArgument(basic_block, kStatePointerArgNum)->addAttr(llvm::Attribute::NoAlias);
+  remill::NthArgument(basic_block, kMemoryPointerArgNum)->addAttr(llvm::Attribute::NoAlias);
 }
 
 // Converts an LLVM module object to have the right triple / data layout


### PR DESCRIPTION
Hello all,

Native instructions are lifted using `__remill_basic_block` clones where the first `state` and the last `memory` parameter presents respectively the CPU state and the memory. 
[The design document](https://github.com/trailofbits/remill/blob/master/docs/LIFE_OF_AN_INSTRUCTION.md) states: "Conceptually, the State structure is not part of a program's memory..."; then should we separate these parameters using `noalias` attribute? 
That allows LLVM optimizes accesses to state and memory better.