### PR TITLE
Check argument index of function

### DIFF
--- a/remill/BC/Util.cpp
+++ b/remill/BC/Util.cpp
@@ -393,9 +393,10 @@ std::string LLVMThingToString(llvm::Type *thing) {
 
 llvm::Argument *NthArgument(llvm::Function *func, size_t index) {
   auto it = func->arg_begin();
-  for (size_t i = 0; i < index; ++i) {
-    ++it;
+  if (index >= static_cast<size_t>(std::distance(it, func->arg_end()))) {
+    return nullptr;
   }
+  std::advance(it, index);
   return &*it;
 }
 


### PR DESCRIPTION
The function [`NthArgument(llvm::Function *func, size_t index)`](https://github.com/trailofbits/remill/blob/master/remill/BC/Util.cpp#L394) return the (pointer to) `index`-th argument of the function `func`. It might be "safer" if we check whether the index corresponds to a valid argument?