### PR TITLE
Add Arch Linux support & update build script to use os-release

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -98,22 +98,22 @@ function DownloadCxxCommon
 # Attempt to detect the OS distribution name.
 function GetOSVersion
 {
-  local distribution_name=$( cat /etc/issue )
+  source /etc/os-release
 
-  case "${distribution_name}" in
-    *Ubuntu*)
+  case "${ID}" in
+    *ubuntu*)
       GetUbuntuOSVersion
       return 0
     ;;
 
-    *openSUSE*)
+    *opensuse*)
       OS_VERSION=opensuse
       return 0
     ;;
 
-    *Arch\ Linux*)
-      printf "[x] Arch Linux is not yet supported.\n"
-      return 1
+    *arch*)
+      OS_VERSION=ubuntu1604
+      return 0
     ;;
 
     *)


### PR DESCRIPTION
Remill's `scripts/build.sh` currently uses `cat /etc/issue` to detect the distribution being used. This is not necessarily the best choice for the task: users are able to modify `/etc/issue`'s contents as they choose and it is designed more as [a login message in tty](http://linuxfromscratch.org/blfs/view/svn/postlfs/logon.html), with character sequences like `\r` and `\l`.

In bash, an `\r` sequence will be read as a [carriage return](https://en.wikipedia.org/wiki/Carriage_return), which can mean losing part of the content we intend to parse using `cat /etc/issue` when we run that command. This is the case on my distribution, Antergos Linux.

The more common tool for getting distribution data is [os-release](https://www.freedesktop.org/software/systemd/man/os-release.html). A quick Google search shows that it is present on at least all the currently-listed distributions in `getOSVersion` (Ubuntu, OpenSUSE, Arch Linux) and others as well (e.g. Fedora, Void Linux).

Having tested remill on my system and found it to work using the CXX libraries for `ubuntu1604`, this small PR would add support for Arch Linux (which Antergos is based on) using `ubuntu1604`, and to use `/etc/os-release` for a more flexible build script.

P.S. Looking at the [list of libraries available](https://s3.amazonaws.com/cxx-common/), it would appear that only `ubuntu1404`, `ubuntu1604` and `osx` are even present as OS versions, i.e. `opensuse` is missing despite it being listed in the build script. That should perhaps be corrected too.