### PR TITLE
Fix NoAlias Attributes for older LLVM versions

### DIFF
--- a/remill/Arch/Arch.cpp
+++ b/remill/Arch/Arch.cpp
@@ -334,7 +334,7 @@ static void AddNoAliasToArgument(llvm::Argument *Arg) {
   );
 
   IF_LLVM_GTE_39(
-    Arg->addAttr(llvm:Attribute::NoAlias);
+    Arg->addAttr(llvm::Attribute::NoAlias);
   );
 }
 

--- a/remill/Arch/Arch.cpp
+++ b/remill/Arch/Arch.cpp
@@ -324,16 +324,16 @@ static void InitBlockFunctionAttributes(llvm::Function *block_func) {
 
 // Add attributes to llvm::Argument in a way portable across LLVMs
 static void AddNoAliasToArgument(llvm::Argument *Arg) {
-  IF_LLVM_LT_50(
-    llvm::AttrBuilder B(llvm::Attribute::NoAlias);
-    Arg->addAttr(llvm::AttributeSet::get(
-      Arg->getContext(),
-      Arg->getArgNo() + 1,
-      B
-      )); 
+  IF_LLVM_LT_39(
+    Arg->addAttr(
+      llvm::AttributeSet::get(
+        Arg->getContext(),
+        Arg->getArgNo() + 1,
+        llvm::Attribute::NoAlias)
+    ); 
   );
 
-  IF_LLVM_GTE_50(
+  IF_LLVM_GTE_39(
     Arg->addAttr(llvm:Attribute::NoAlias);
   );
 }

--- a/remill/Arch/Arch.cpp
+++ b/remill/Arch/Arch.cpp
@@ -323,18 +323,18 @@ static void InitBlockFunctionAttributes(llvm::Function *block_func) {
 }  // namespace
 
 // Add attributes to llvm::Argument in a way portable across LLVMs
-static void AddNoAliasToArgument(llvm::Argument *Arg) {
+static void AddNoAliasToArgument(llvm::Argument *arg) {
   IF_LLVM_LT_39(
-    Arg->addAttr(
+    arg->addAttr(
       llvm::AttributeSet::get(
-        Arg->getContext(),
-        Arg->getArgNo() + 1,
+        arg->getContext(),
+        arg->getArgNo() + 1,
         llvm::Attribute::NoAlias)
     ); 
   );
 
   IF_LLVM_GTE_39(
-    Arg->addAttr(llvm::Attribute::NoAlias);
+    arg->addAttr(llvm::Attribute::NoAlias);
   );
 }
 

--- a/remill/Arch/Arch.cpp
+++ b/remill/Arch/Arch.cpp
@@ -322,6 +322,22 @@ static void InitBlockFunctionAttributes(llvm::Function *block_func) {
 
 }  // namespace
 
+// Add attributes to llvm::Argument in a way portable across LLVMs
+static void AddNoAliasToArgument(llvm::Argument *Arg) {
+  IF_LLVM_LT_50(
+    llvm::AttrBuilder B(llvm::Attribute::NoAlias);
+    Arg->addAttr(llvm::AttributeSet::get(
+      Arg->getContext(),
+      Arg->getArgNo() + 1,
+      B
+      )); 
+  );
+
+  IF_LLVM_GTE_50(
+    Arg->addAttr(llvm:Attribute::NoAlias);
+  );
+}
+
 // ensures that mandatory remill functions have the correct
 // type signature and variable names
 static void PrepareModuleRemillFunctions(llvm::Module *mod) {
@@ -337,8 +353,8 @@ static void PrepareModuleRemillFunctions(llvm::Module *mod) {
   basic_block->addFnAttr(llvm::Attribute::NoInline);
   basic_block->setVisibility(llvm::GlobalValue::DefaultVisibility);
 
-  remill::NthArgument(basic_block, kStatePointerArgNum)->addAttr(llvm::Attribute::NoAlias);
-  remill::NthArgument(basic_block, kMemoryPointerArgNum)->addAttr(llvm::Attribute::NoAlias);
+  AddNoAliasToArgument(remill::NthArgument(basic_block, kStatePointerArgNum));
+  AddNoAliasToArgument(remill::NthArgument(basic_block, kMemoryPointerArgNum));
 }
 
 // Converts an LLVM module object to have the right triple / data layout


### PR DESCRIPTION
Properly add noAlias for older LLVMs (tested on 3.8).

Requesting someone do a sanity check on 4.0 and 5.0+