### PR TITLE
Compile Options for BC Language Targets

### DIFF
--- a/cmake/BCCompiler/CMakeBCInformation.cmake
+++ b/cmake/BCCompiler/CMakeBCInformation.cmake
@@ -79,6 +79,7 @@ function (add_runtime target_name)
 
     add_executable("${target_name}" ${source_file_list})
     target_compile_definitions("${target_name}" PRIVATE ${definitions})
+    target_compile_options("${target_name}" PRIVATE ${options})
     set_target_properties("${target_name}" PROPERTIES SUFFIX ".bc")
 
     foreach (source_file ${sourcefile_list})


### PR DESCRIPTION
Sets target compile options for BC language targets. 

* Enables usage of `-m32` to generate 32-bit code on amd64 machines.

Necessary to close mcsema issue #442 (https://github.com/trailofbits/mcsema/issues/442)