### PR TITLE
revert missing global CR(s) and DR(s)

### DIFF
--- a/remill/Arch/X86/Runtime/BasicBlock.cpp
+++ b/remill/Arch/X86/Runtime/BasicBlock.cpp
@@ -332,6 +332,26 @@ Memory *__remill_basic_block(State &state, addr_t curr_pc, Memory *memory) {
   auto &SF = state.aflag.sf;
   auto &ZF = state.aflag.zf;
 
+  // Debug registers. No-ops keep them from being stripped off the module.
+  auto &_DR0 = DR0;
+  auto &_DR1 = DR1;
+  auto &_DR2 = DR2;
+  auto &_DR3 = DR3;
+  auto &_DR4 = DR4;
+  auto &_DR5 = DR5;
+  auto &_DR6 = DR6;
+  auto &_DR7 = DR7;
+
+  // Control registers
+  auto &_CR0 = CR0;
+  auto &_CR1 = CR1;
+  auto &_CR2 = CR2;
+  auto &_CR3 = CR3;
+  auto &_CR4 = CR4;
+#if 64 == ADDRESS_SIZE_BITS
+  auto &_CR8 = CR8;
+#endif
+
   // Lifted code will be placed here in clones versions of this function.
   return memory;
 }

--- a/tests/X86/Run.cpp
+++ b/tests/X86/Run.cpp
@@ -132,22 +132,24 @@ uint8_t *gStackSwitcher = nullptr;
 uint64_t gStackSaveSlot = 0;
 
 // Debug registers.
-uint64_t gDR0;
-uint64_t gDR1;
-uint64_t gDR2;
-uint64_t gDR3;
-uint64_t gDR4;
-uint64_t gDR5;
-uint64_t gDR6;
-uint64_t gDR7;
+uint64_t DR0;
+uint64_t DR1;
+uint64_t DR2;
+uint64_t DR3;
+uint64_t DR4;
+uint64_t DR5;
+uint64_t DR6;
+uint64_t DR7;
 
-// Control regs.
-CR0Reg gCR0;
-CR1Reg gCR1;
-CR2Reg gCR2;
-CR3Reg gCR3;
-CR4Reg gCR4;
-CR8Reg gCR8;
+// Control registers.
+CR0Reg CR0;
+CR1Reg CR1;
+CR2Reg CR2;
+CR3Reg CR3;
+CR4Reg CR4;
+#if 64 == ADDRESS_SIZE_BITS
+CR8Reg CR8;
+#endif
 
 // Invoke a native test case addressed by `gTestToRun` and store the machine
 // state before and after executing the test in `gLiftedState` and


### PR DESCRIPTION
Alternative attempt for #285.