### PR TITLE
add vector update macro

### DIFF
--- a/remill/Arch/Runtime/Operators.h
+++ b/remill/Arch/Runtime/Operators.h
@@ -1193,6 +1193,34 @@ MAKE_INSERTV(F, 64, float64_t, doubles)
 
 #undef MAKE_INSERTV
 
+// Update the Nth element of an aggregate vector.
+#define MAKE_UPDATEV(prefix, size, base_type, accessor) \
+    template <typename T> \
+    ALWAYS_INLINE static \
+    void prefix ## UpdateV ## size(T &vec, size_t n, base_type val) { \
+      static_assert( \
+          sizeof(base_type) == sizeof(typename VectorType<T>::BT), \
+          "Invalid update"); \
+      vec.elems[n] = val; \
+    }
+
+MAKE_UPDATEV(U, 8, uint8_t, bytes)
+MAKE_UPDATEV(U, 16, uint16_t, words)
+MAKE_UPDATEV(U, 32, uint32_t, dwords)
+MAKE_UPDATEV(U, 64, uint64_t, qwords)
+MAKE_UPDATEV(U, 128, uint128_t, dqwords)
+
+MAKE_UPDATEV(S, 8, int8_t, sbytes)
+MAKE_UPDATEV(S, 16, int16_t, swords)
+MAKE_UPDATEV(S, 32, int32_t, sdwords)
+MAKE_UPDATEV(S, 64, int64_t, sqwords)
+MAKE_UPDATEV(S, 128, int128_t, sdqwords)
+
+MAKE_UPDATEV(F, 32, float32_t, floats)
+MAKE_UPDATEV(F, 64, float64_t, doubles)
+
+#undef MAKE_UPDATEV
+
 template <typename U, typename T>
 ALWAYS_INLINE static constexpr
 T _ZeroVec(void) {

--- a/remill/Arch/X86/Semantics/SSE.cpp
+++ b/remill/Arch/X86/Semantics/SSE.cpp
@@ -284,7 +284,7 @@ DEF_SEM(PSHUFD, D dst, S1 src1, I8 src2) {
       auto shift = UMul(sel, 32_u8);
       order = UShr(order, 2_u8);
       auto sel_val = UShr(group, UInt128(shift));
-      dst_vec = UInsertV32(dst_vec, k, TruncTo<uint32_t>(sel_val));
+      UUpdateV32(dst_vec, k, TruncTo<uint32_t>(sel_val));
     }
   }
   UWriteV32(dst, dst_vec);


### PR DESCRIPTION
Hello all,

This is an "experimental feature" that may improve the lifting result: in some semantics functions of vectored instructions, the macro `_Insert_` can be replaced by `_Update_` which simply updates the vector instead of "copy-update". 

Concretely, I have [modified](https://github.com/trailofbits/remill/pull/293/files#diff-ad103422aab8c2d7d4f4aa2999e5f4f2L287) the semantics function of `pshufd_v128_v128` in this PR, the code generated, without any difference in optimization options, for this function (extracted from the binary `run-amd64-tests`) is much shorter:

```
push rbp                              push rbp
mov rbp, rsp                          mov rbp, rsp
mov rax, [rdi+0x10]                   mov rax, [rdi+0x10]
xorps xmm0, xmm0                      mov rcx, rax
movaps [rbp-0x10], xmm0               shr rcx, 0x20
mov [rbp-0x10], eax                   mov [rdi+0x110], eax
mov rcx, [rbp-0x10]                   mov [rdi+0x114], ecx
shr rax, 0x20                         mov [rdi+0x118], eax
mov [rbp-0x10], rcx                   mov [rdi+0x11c], ecx
mov qword ptr [rbp-0x8], 0x0          mov eax, [rdi+0x54]
mov [rbp-0xc], eax                    mov [rdi+0x150], eax
mov rcx, [rbp-0x10]                   mov [rdi+0x154], eax
mov [rbp-0x10], rcx                   mov [rdi+0x158], eax
mov [rbp-0x4], eax                    mov [rdi+0x15c], eax
mov rax, [rbp-0x8]                    mov eax, [rdi+0x94]
mov [rdi+0x110], ecx                  mov ecx, [rdi+0x98]
shr rcx, 0x20                         mov [rdi+0x190], ecx
mov [rdi+0x114], ecx                  mov [rdi+0x194], eax
mov [rdi+0x118], eax                  mov [rdi+0x198], ecx
shr rax, 0x20                         mov [rdi+0x19c], eax
mov [rdi+0x11c], eax                  add rsi, 0x14
mov eax, [rdi+0x54]                   mov [rdi+0x9a8], rsi
movaps [rbp-0x10], xmm0               mov eax, [rdi+0xd4]
mov [rbp-0x10], eax                   mov ecx, [rdi+0xdc]
mov rcx, [rbp-0x10]                   mov [rdi+0x1d0], ecx
mov [rbp-0x10], rcx                   mov [rdi+0x1d4], eax
mov qword ptr [rbp-0x8], 0x0          mov [rdi+0x1d8], ecx
mov [rbp-0xc], eax                    mov [rdi+0x1dc], eax
mov rcx, [rbp-0x10]                   pop rbp
mov [rbp-0x10], rcx                   jmp __remill_missing_block
mov [rbp-0x4], eax                    
mov rax, [rbp-0x8]                    
mov [rdi+0x150], ecx                  
shr rcx, 0x20                         
mov [rdi+0x154], ecx                  
mov [rdi+0x158], eax                  
shr rax, 0x20                         
mov [rdi+0x15c], eax                  
mov eax, [rdi+0x94]                   
mov ecx, [rdi+0x98]                   
movaps [rbp-0x10], xmm0               
mov [rbp-0x10], ecx                   
mov rcx, [rbp-0x10]                   
mov [rbp-0x10], rcx                   
mov qword ptr [rbp-0x8], 0x0          
mov [rbp-0xc], eax                    
mov rcx, [rbp-0x10]                   
mov [rbp-0x10], rcx                   
mov [rbp-0x4], eax                    
mov rax, [rbp-0x8]                    
mov [rdi+0x190], ecx                  
shr rcx, 0x20                         
mov [rdi+0x194], ecx                  
mov [rdi+0x198], eax                  
shr rax, 0x20                         
mov [rdi+0x19c], eax                  
add rsi, 0x14                         
mov [rdi+0x9a8], rsi                  
mov eax, [rdi+0xd4]                   
mov ecx, [rdi+0xdc]                   
movaps [rbp-0x10], xmm0               
mov [rbp-0x10], ecx                   
mov rcx, [rbp-0x10]                   
mov [rbp-0x10], rcx                   
mov qword ptr [rbp-0x8], 0x0          
mov [rbp-0xc], eax                    
mov rcx, [rbp-0x10]                   
mov [rbp-0x10], rcx                   
mov [rbp-0x4], eax                    
mov rax, [rbp-0x8]                    
mov [rdi+0x1d0], ecx                  
shr rcx, 0x20                         
mov [rdi+0x1d4], ecx                  
mov [rdi+0x1d8], eax                  
shr rax, 0x20                         
mov [rdi+0x1dc], eax                  
pop rbp                               
jmp __remill_missing_block
```