### PR TITLE
Pass arguments to CMake from build.sh

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -275,7 +275,13 @@ function main
 
       # Make the build type to be a debug build.
       --debug)
-        BUILD_FLAGS="-DCMAKE_BUILD_TYPE=Debug"
+        BUILD_FLAGS="${BUILD_FLAGS} -DCMAKE_BUILD_TYPE=Debug"
+        printf "[+] Enabling a debug build of remill\n"
+      ;;
+
+      --extra-cmake-args)
+        BUILD_FLAGS="${BUILD_FLAGS} ${2}"
+        printf "[+] Will supply additional arguments to cmake: ${BUILD_FLAGS}\n"
         shift
       ;;
 


### PR DESCRIPTION

* Allow for extra args to cmake during build.

Used to pass arguments that permit ABI libraries to be built with McSema, but can be used for any cmake build arg.