### PR TITLE
Pass FINDPACKAGE_LLVM_HINTS to parent scope in FindAndSelectClangCompiler

### DIFF
--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -8,6 +8,7 @@ function(FindAndSelectClangCompiler)
   if(DEFINED LLVM_INSTALL_PREFIX)
     list(APPEND FINDPACKAGE_LLVM_HINTS "${LLVM_INSTALL_PREFIX}/lib/cmake/llvm/")
     list(APPEND FINDPACKAGE_LLVM_HINTS "${LLVM_INSTALL_PREFIX}/share/llvm/cmake/")
+    set(FINDPACKAGE_LLVM_HINTS ${FINDPACKAGE_LLVM_HINTS} PARENT_SCOPE)
 
     message(STATUS "Using LLVM_INSTALL_PREFIX hints for find_package(LLVM): ${FINDPACKAGE_LLVM_HINTS}")
   endif()


### PR DESCRIPTION
In `CMakeLists.txt:50`, the `FINDPACKAGE_LLVM_HINTS` variable is used, but this variable is only assigned in the `FindAndSelectClangCompiler` function, with a local scope. 

As a result, in `CMakeLists.txt:50`, an empty value is used for `FINDPACKAGE_LLVM_HINTS`.

This PR assigns  `FINDPACKAGE_LLVM_HINTS` with[ `PARENT_SCOPE`](https://cmake.org/cmake/help/v3.2/command/set.html) visibility in `FindAndSelectClangCompiler()` CMake function,  so that it is visible to the caller.
