### PR TITLE
Prefer using LLVM_PREFIX if available to find clang and llvm-link programs

### DIFF
--- a/cmake/BCCompiler.cmake
+++ b/cmake/BCCompiler.cmake
@@ -28,20 +28,39 @@ if(DEFINED ENV{LLVM_INSTALL_PREFIX})
   set(LLVM_INSTALL_PREFIX $ENV{LLVM_INSTALL_PREFIX})
 endif()
 
-if("${CMAKE_CXX_COMPILER}" STREQUAL "${CLANG_CXX_EXECUTABLE_NAME}")
-  set(CLANG_PATH "${CMAKE_CXX_COMPILER}")
-
-else()
+if (DEFINED LLVM_INSTALL_PREFIX)
+  message(STATUS "LLVM bin dir: ${LLVM_INSTALL_PREFIX}/bin")
+  # clang path
   find_program(CLANG_PATH
     NAMES "${CLANG_CXX_EXECUTABLE_NAME}"
+    HINTS "${LLVM_INSTALL_PREFIX}/bin"
+    NO_DEFAULT_PATH
+  )
+
+  # llvm-link path
+  find_program(LLVMLINK_PATH
+    NAMES "${LLVMLINK_EXECUTABLE_NAME}"
+    HINTS "${LLVM_INSTALL_PREFIX}/bin"
+    NO_DEFAULT_PATH
+  )
+else()
+  # clang path
+  if("${CMAKE_CXX_COMPILER}" STREQUAL "${CLANG_CXX_EXECUTABLE_NAME}")
+    set(CLANG_PATH "${CMAKE_CXX_COMPILER}")
+
+  else()
+    find_program(CLANG_PATH
+      NAMES "${CLANG_CXX_EXECUTABLE_NAME}"
+      PATHS "/usr/bin" "/usr/local/bin" "${LLVM_INSTALL_PREFIX}/bin" "${LLVM_TOOLS_BINARY_DIR}" "C:/Program Files/LLVM/bin" "C:/Program Files (x86)/LLVM/bin"
+    )
+  endif()
+
+  # llvm-link path
+  find_program(LLVMLINK_PATH
+    NAMES "${LLVMLINK_EXECUTABLE_NAME}"
     PATHS "/usr/bin" "/usr/local/bin" "${LLVM_INSTALL_PREFIX}/bin" "${LLVM_TOOLS_BINARY_DIR}" "C:/Program Files/LLVM/bin" "C:/Program Files (x86)/LLVM/bin"
   )
 endif()
-
-find_program(LLVMLINK_PATH
-  NAMES "${LLVMLINK_EXECUTABLE_NAME}"
-  PATHS "/usr/bin" "/usr/local/bin" "${LLVM_INSTALL_PREFIX}/bin" "${LLVM_TOOLS_BINARY_DIR}" "C:/Program Files/LLVM/bin" "C:/Program Files (x86)/LLVM/bin"
-)
 
 if((NOT "${CLANG_PATH}" MATCHES "CLANG_PATH-NOTFOUND") AND (NOT "${LLVMLINK_PATH}" MATCHES "LLVMLINK_PATH-NOTFOUND"))
   file(WRITE "${CMAKE_BINARY_DIR}/emitllvm.test.cpp" "int main(int argc, char* argv[]){return 0;}\n\n")


### PR DESCRIPTION
Before this PR, when specifying a `LLVM_PREFIX`, it is not used to determine the `CLANG_PATH` and the `LLVMLINK_PATH`, if these binaries are available system-wide.

After this PR, if `LLVM_PREFIX` has been specified, only this variable is used to determine `CLANG_PATH` and `LLVMLINK_PATH`. If it hasn't been specified, the lookup code is unchanged.

Depending on the precise semantics attached to `LLVM_PREFIX`, this may or may be the wanted behavior. Alternatively, we could first check only looking at the `LLVM_PREFIX` path, and then the other paths if not found.
The method I chose has the property that the user cannot accidentally have a `CLANG_PATH` or `LLVMLINK_PATH` not matching their `LLVM_PREFIX`. 
I chose this method because I believe that when the `LLVM_PREFIX` is specified, it precisely conveys the intent to use it, and so it should completely replace the system paths. 

I can change this PR if this is not the wanted behavior.