### PR TITLE
add float128 type

### DIFF
--- a/remill/Arch/Runtime/Intrinsics.cpp
+++ b/remill/Arch/Runtime/Intrinsics.cpp
@@ -49,10 +49,12 @@ extern "C" void __remill_intrinsics(void) {
   USED(__remill_read_memory_f32);
   USED(__remill_read_memory_f64);
   USED(__remill_read_memory_f80);
+  USED(__remill_read_memory_f128);
 
   USED(__remill_write_memory_f32);
   USED(__remill_write_memory_f64);
   USED(__remill_write_memory_f80);
+  USED(__remill_write_memory_f128);
 
   USED(__remill_barrier_load_load);
   USED(__remill_barrier_load_store);

--- a/remill/Arch/Runtime/Intrinsics.h
+++ b/remill/Arch/Runtime/Intrinsics.h
@@ -60,11 +60,17 @@ extern float64_t __remill_read_memory_f64(Memory *, addr_t);
 [[gnu::used]]
 extern float64_t __remill_read_memory_f80(Memory *, addr_t);
 
+[[gnu::used]]
+extern float128_t __remill_read_memory_f128(Memory *, addr_t);
+
 [[gnu::used, gnu::const]]
 extern Memory *__remill_write_memory_f32(Memory *, addr_t, float32_t);
 
 [[gnu::used, gnu::const]]
 extern Memory *__remill_write_memory_f64(Memory *, addr_t, float64_t);
+
+[[gnu::used]]
+extern Memory *__remill_write_memory_f128(Memory *, addr_t, float128_t);
 
 [[gnu::used]]
 extern Memory *__remill_write_memory_f80(Memory *, addr_t, float64_t);

--- a/remill/Arch/Runtime/Operators.h
+++ b/remill/Arch/Runtime/Operators.h
@@ -124,6 +124,11 @@ float64_t _Read(Memory *, In<float64_t> imm) {
   return reinterpret_cast<const float64_t &>(imm.val);
 }
 
+ALWAYS_INLINE static
+float128_t _Read(Memory *, In<float128_t> imm) {
+  return reinterpret_cast<const float128_t &>(imm.val);
+}
+
 template <typename T>
 ALWAYS_INLINE static
 T _Read(Memory *, In<T> imm) {
@@ -165,6 +170,7 @@ MAKE_MREAD(128, 128, uint, 128)
 MAKE_MREAD(32, 32, float, f32)
 MAKE_MREAD(64, 64, float, f64)
 MAKE_MREAD(80, 64, float, f80)
+MAKE_MREAD(128, 128, float, f128)
 
 #undef MAKE_MREAD
 
@@ -191,6 +197,7 @@ MAKE_RWRITE(uint32_t)
 MAKE_RWRITE(uint64_t)
 MAKE_RWRITE(float32_t)
 MAKE_RWRITE(float64_t)
+MAKE_RWRITE(float128_t)
 
 #undef MAKE_RWRITE
 
@@ -213,6 +220,7 @@ MAKE_MWRITE(128, 128, uint, uint, 128)
 MAKE_MWRITE(32, 32, float, float, f32)
 MAKE_MWRITE(64, 64, float, float, f64)
 MAKE_MWRITE(80, 64, float, float, f80)
+MAKE_MWRITE(128, 128, float, float, f128)
 
 #undef MAKE_MWRITE
 
@@ -243,6 +251,7 @@ MAKE_READRV(S, 64, sqwords, int64_t)
 
 MAKE_READRV(F, 32, floats, float32_t)
 MAKE_READRV(F, 64, doubles, float64_t)
+MAKE_READRV(F, 128, ldoubles, float128_t)
 
 #undef MAKE_READRV
 
@@ -275,6 +284,7 @@ MAKE_READV(S, 128, sdqwords)
 
 MAKE_READV(F, 32, floats)
 MAKE_READV(F, 64, doubles)
+MAKE_READV(F, 128, ldoubles)
 
 #undef MAKE_READV
 
@@ -321,6 +331,7 @@ MAKE_MREADV(S, 128, sdqwords, s128)
 
 MAKE_MREADV(F, 32, floats, f32)
 MAKE_MREADV(F, 64, doubles, f64)
+MAKE_MREADV(F, 128, ldoubles, f128)
 
 #undef MAKE_MREADV
 
@@ -374,6 +385,7 @@ MAKE_WRITEV(S, 128, sdqwords, VnW, int128_t)
 
 MAKE_WRITEV(F, 32, floats, VnW, float32_t)
 MAKE_WRITEV(F, 64, doubles, VnW, float64_t)
+MAKE_WRITEV(F, 128, ldoubles, VnW, float128_t)
 
 MAKE_WRITEV(U, 8, bytes, RVnW, uint8_t)
 MAKE_WRITEV(U, 16, words, RVnW, uint16_t)
@@ -387,6 +399,7 @@ MAKE_WRITEV(S, 64, sqwords, RVnW, int64_t)
 
 MAKE_WRITEV(F, 32, floats, RVnW, float32_t)
 MAKE_WRITEV(F, 64, doubles, RVnW, float64_t)
+MAKE_WRITEV(F, 128, ldoubles, RVnW, float128_t)
 
 #undef MAKE_WRITEV
 
@@ -443,6 +456,7 @@ MAKE_MWRITEV(S, 128, sdqwords, s128, int128_t)
 
 MAKE_MWRITEV(F, 32, floats, f32, float32_t)
 MAKE_MWRITEV(F, 64, doubles, f64, float64_t)
+MAKE_MWRITEV(F, 128, ldoubles, f128, float128_t)
 
 #undef MAKE_MWRITEV
 
@@ -461,6 +475,7 @@ MAKE_WRITE_REF(uint64_t)
 MAKE_WRITE_REF(uint128_t)
 MAKE_WRITE_REF(float32_t)
 MAKE_WRITE_REF(float64_t)
+MAKE_WRITE_REF(float128_t)
 
 #undef MAKE_WRITE_REF
 
@@ -855,6 +870,10 @@ auto TruncTo(T val) -> typename IntegerType<DT>::BT {
       memory = _FWriteV64(memory, op, (val)); \
     } while (false)
 
+#define FWriteV128(op, val) \
+    do { \
+      memory = _FWriteV128(memory, op, (val)); \
+    } while (false)
 
 #define SReadV8(op) _SReadV8(memory, op)
 #define UReadV8(op) _UReadV8(memory, op)
@@ -873,6 +892,7 @@ auto TruncTo(T val) -> typename IntegerType<DT>::BT {
 
 #define FReadV32(op) _FReadV32(memory, op)
 #define FReadV64(op) _FReadV64(memory, op)
+#define FReadV128(op) _FReadV128(memory, op)
 
 // Useful for stubbing out an operator.
 #define MAKE_NOP(...)

--- a/remill/Arch/Runtime/Types.h
+++ b/remill/Arch/Runtime/Types.h
@@ -61,6 +61,9 @@ static_assert(4 == sizeof(float32_t), "Invalid `float32_t` size.");
 typedef double float64_t;
 static_assert(8 == sizeof(float64_t), "Invalid `float64_t` size.");
 
+typedef __float128 float128_t;
+static_assert(16 == sizeof(float128_t), "Invalid `float128_t` size.");
+
 // TODO(pag): Assumes little endian.
 struct float80_t final {
   uint8_t data[10];
@@ -248,6 +251,10 @@ MAKE_VECTOR(double, float64, 2, 128, 16);
 MAKE_VECTOR(double, float64, 4, 256, 32);
 MAKE_VECTOR(double, float64, 8, 512, 64);
 
+MAKE_VECTOR(__float128, float128, 1, 128, 16);
+MAKE_VECTOR(__float128, float128, 2, 256, 32);
+MAKE_VECTOR(__float128, float128, 4, 512, 64);
+
 #define NumVectorElems(val) \
     static_cast<addr_t>(VectorType<decltype(val)>::kNumElems)
 
@@ -326,6 +333,7 @@ union vec128_t final {
   uint64v2_t qwords;
   float32v4_t floats;
   float64v2_t doubles;
+  float128v1_t ldoubles;
 
   int8v16_t sbytes;
   int16v8_t swords;
@@ -345,6 +353,7 @@ union vec256_t final {
   uint128v2_t dqwords;
   float32v8_t floats;
   float64v4_t doubles;
+  float128v2_t ldoubles;
 
   int8v32_t sbytes;
   int16v16_t swords;
@@ -364,6 +373,7 @@ union vec512_t final {
   uint128v4_t dqwords;
   float32v16_t floats;
   float64v8_t doubles;
+  float128v4_t ldoubles;
 
   int8v64_t sbytes;
   int16v32_t swords;

--- a/remill/Arch/X86/Semantics/DATAXFER.cpp
+++ b/remill/Arch/X86/Semantics/DATAXFER.cpp
@@ -47,7 +47,7 @@ DEF_SEM(MOVD, D dst, S src) {
 
 template <typename D, typename S>
 DEF_SEM(MOVxPS, D dst, S src) {
-  FWriteV32(dst, FReadV32(src));
+  FWriteV128(dst, FReadV128(src));
   return memory;
 }
 

--- a/remill/BC/IntrinsicTable.cpp
+++ b/remill/BC/IntrinsicTable.cpp
@@ -92,10 +92,12 @@ IntrinsicTable::IntrinsicTable(llvm::Module *module)
 
       read_memory_f32(FindPureIntrinsic(module, "__remill_read_memory_f32")),
       read_memory_f64(FindPureIntrinsic(module, "__remill_read_memory_f64")),
+      read_memory_f128(FindPureIntrinsic(module, "__remill_read_memory_f128")),
       read_memory_f80(FindPureIntrinsic(module, "__remill_read_memory_f80")),
 
       write_memory_f32(FindPureIntrinsic(module, "__remill_write_memory_f32")),
       write_memory_f64(FindPureIntrinsic(module, "__remill_write_memory_f64")),
+      write_memory_f128(FindPureIntrinsic(module, "__remill_write_memory_f128")),
       write_memory_f80(FindPureIntrinsic(
           module, "__remill_write_memory_f80")),
 

--- a/remill/BC/IntrinsicTable.h
+++ b/remill/BC/IntrinsicTable.h
@@ -58,10 +58,12 @@ class IntrinsicTable {
 
   llvm::Function * const read_memory_f32;
   llvm::Function * const read_memory_f64;
+  llvm::Function * const read_memory_f128;
   llvm::Function * const read_memory_f80;
 
   llvm::Function * const write_memory_f32;
   llvm::Function * const write_memory_f64;
+  llvm::Function * const write_memory_f128;
   llvm::Function * const write_memory_f80;
 
   // Memory barriers.
@@ -83,6 +85,7 @@ class IntrinsicTable {
   llvm::Function *undefined_64;
   llvm::Function *undefined_f32;
   llvm::Function *undefined_f64;
+  llvm::Function *undefined_f128;
 //
 //  llvm::ConstantArray *indirect_blocks;
 //  llvm::ConstantArray *exported_blocks;

--- a/tests/X86/Run.cpp
+++ b/tests/X86/Run.cpp
@@ -185,6 +185,7 @@ MAKE_RW_MEMORY(64)
 
 MAKE_RW_FP_MEMORY(32)
 MAKE_RW_FP_MEMORY(64)
+MAKE_RW_FP_MEMORY(128)
 
 NEVER_INLINE float64_t __remill_read_memory_f80(Memory *, addr_t addr) {
   LongDoubleStorage storage;


### PR DESCRIPTION
Hello all,

With the goal of simplifying [movaps](https://github.com/trailofbits/remill/compare/master...tathanhdinh:fp128?expand=1#diff-999092029e9e7e4d0e50a5cffa8a497dL50) instruction, this PR tries to add the type `__float128` into remill.