### PR TITLE
FP cast for win32 fix

### DIFF
--- a/remill/BC/Lifter.cpp
+++ b/remill/BC/Lifter.cpp
@@ -410,6 +410,10 @@ static llvm::Value *ConvertToIntendedType(Instruction &inst, Operand &op,
     } else if (intended_type->isIntegerTy()) {
       return new llvm::PtrToIntInst(val, intended_type, "", block);
     }
+  } else if (val_type->isFloatingPointTy()) {
+    if (intended_type->isIntegerTy()) {
+      return new llvm::FPToSIInst(val, intended_type, "", block);
+    }
   }
 
   LOG(FATAL)

--- a/remill/BC/Lifter.cpp
+++ b/remill/BC/Lifter.cpp
@@ -413,8 +413,6 @@ static llvm::Value *ConvertToIntendedType(Instruction &inst, Operand &op,
   } else if (val_type->isFloatingPointTy()) {
     if (intended_type->isIntegerTy()) {
       return new llvm::FPToSIInst(val, intended_type, "", block);
-    } else if (intended_type->isPointerTy()) {
-      return new llvm::BitCastInst(val, intended_type, "", block);
     }
   }
 

--- a/remill/BC/Lifter.cpp
+++ b/remill/BC/Lifter.cpp
@@ -413,6 +413,8 @@ static llvm::Value *ConvertToIntendedType(Instruction &inst, Operand &op,
   } else if (val_type->isFloatingPointTy()) {
     if (intended_type->isIntegerTy()) {
       return new llvm::FPToSIInst(val, intended_type, "", block);
+    } else if (intended_type->isPointerTy()) {
+      return new llvm::BitCastInst(val, intended_type, "", block);
     }
   }
 

--- a/remill/BC/Lifter.cpp
+++ b/remill/BC/Lifter.cpp
@@ -412,7 +412,7 @@ static llvm::Value *ConvertToIntendedType(Instruction &inst, Operand &op,
     }
   } else if (val_type->isFloatingPointTy()) {
     if (intended_type->isIntegerTy()) {
-      return new llvm::FPToSIInst(val, intended_type, "", block);
+      return new llvm::BitCastInst(val, intended_type, "", block);
     }
   }
 


### PR DESCRIPTION
`ConvertToIntendedType` fails for the FP instructions because of the missing type conversion for FP type. The PR fixes https://github.com/trailofbits/mcsema/issues/498.