### PR TITLE
Supporting Intel's far jumps

### DIFF
--- a/remill/Arch/Runtime/HyperCall.h
+++ b/remill/Arch/Runtime/HyperCall.h
@@ -87,6 +87,9 @@ class AsyncHyperCall {
     kX86SysEnter,
     kX86SysExit,
 
+    // Far jumps: CS should be updated.
+    kX86JmpFar,
+
     kAArch64SupervisorCall,
 
     // Invalid instruction.


### PR DESCRIPTION
Hello all,

The PR tries to handle the issue #288. Now remill can lift far jumps instructions, for example

```Assembly
ea 5f b9 15 77 33 00    jmp far 0x33:0x7715b95f
```

will has string presentation

```Lisp
(X86 0 7 (BYTES ea 5f b9 15 77 33 00) 
   JMP_FAR_PTRp_IMMw_32 
     (READ_OP (PTR_32 7715b95f)) 
     (READ_OP (IMM_16 33)))
```

and is lifted into

```
remill-lift-7.0 --arch x86 --bytes  ea5fb915773300 --ir-out /dev/stdout
...
define dso_local %struct.Memory* @sub_0(%struct.State* noalias dereferenceable(3376), i32, %struct.Memory* noalias) {
  %4 = getelementptr inbounds %struct.State, %struct.State* %0, i32 0, i32 6, i32 33, i32 0, i32 0
  %5 = getelementptr inbounds %struct.State, %struct.State* %0, i32 0, i32 0, i32 0
  store i32 11, i32* %5, align 16
  store i32 1997912415, i32* %4, align 4
  %6 = getelementptr inbounds %struct.State, %struct.State* %0, i32 0, i32 4, i32 11, i32 0
  store i16 51, i16* %6, align 2
  %7 = tail call %struct.Memory* @__remill_async_hyper_call(%struct.State* nonnull dereferenceable(3376) %0, i32 1997912415, %struct.Memory* %2) #3
  %8 = load i32, i32* %4, align 4
  %9 = tail call %struct.Memory* @__remill_jump(%struct.State* nonnull %0, i32 %8, %struct.Memory* %7)
  ret %struct.Memory* %9
}
...
```

Many thanks for any comment.
