### PR TITLE
Add support for llvm 8.0 to the build script

### DIFF
--- a/remill/BC/DeadStoreEliminator.cpp
+++ b/remill/BC/DeadStoreEliminator.cpp
@@ -199,11 +199,9 @@ static bool TryGetOffsetOrConst(
       *offset_out = static_cast<uint64_t>(const_val->getSExtValue());
       return true;
     } else {
-      llvm::SmallString<32> str;
-      (void) val_apint.toStringSigned(str);
       LOG(ERROR)
           << "Unable to fit offset from " << remill::LLVMThingToString(val)
-          << " into a 64-bit signed integer: " << str.str().str();
+          << " into a 64-bit signed integer";
       return false;
     }
   } else {


### PR DESCRIPTION
Also adds a new compiler option, `--use-host-compiler`, which looks for `$CC` and `$CXX` in place of using our build of Clang. In the case of LLVM < 5.0, using the host compiler is the default behaviour.