### PR TITLE
Fixed POP xSP

### DIFF
--- a/remill/Arch/X86/Semantics/POP.cpp
+++ b/remill/Arch/X86/Semantics/POP.cpp
@@ -27,8 +27,8 @@ DEF_SEM(POP, D dst) {
   addr_t op_size = ZExtTo<D>(ByteSizeOf(dst));
   addr_t old_xsp = Read(REG_XSP);
   addr_t new_xsp = UAdd(old_xsp, op_size);
-  WriteZExt(dst, Read(ReadPtr<D>(old_xsp _IF_32BIT(REG_SS_BASE))));
   Write(REG_XSP, new_xsp);
+  WriteZExt(dst, Read(ReadPtr<D>(old_xsp _IF_32BIT(REG_SS_BASE))));
   return memory;
 }
 

--- a/tests/X86/POP/POP.S
+++ b/tests/X86/POP/POP.S
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+TEST_BEGIN_64(POPrsp_64_ADD8, 1)
+TEST_INPUTS(0)
+    push rsp
+    add qword ptr [rsp], 8
+    pop rsp
+TEST_END_64
+
 TEST_BEGIN_64(POPrsp_64, 1)
 TEST_INPUTS(0)
     push rsp


### PR DESCRIPTION
I tried to lift the **POP RSP** instruction and this was the result:

```
define dso_local %struct.Memory* @sub_0(%struct.State* noalias dereferenceable(3376), i64, %struct.Memory* noalias) local_unnamed_addr #0 {
entry:
  %3 = getelementptr inbounds %struct.State, %struct.State* %0, i64 0, i32 6, i32 33, i32 0, i32 0
  ; %4 = RSP pointer
  %4 = getelementptr inbounds %struct.State, %struct.State* %0, i64 0, i32 6, i32 13, i32 0, i32 0
  %5 = add i64 %1, 1
  store i64 %5, i64* %3, align 8
  ; %6 = RSP value
  %6 = load i64, i64* %4, align 8
  ; %7 = RSP + 8
  %7 = add i64 %6, 8
  ; saving RSP + 8 into RSP pointer: WRONG
  store i64 %7, i64* %4, align 8
  %8 = tail call %struct.Memory* @__remill_missing_block(%struct.State* nonnull %0, i64 %5, %struct.Memory* %2)
  ret %struct.Memory* %8
}
```

**xSP** should get the value popped from the stack instead of being updated with **xSP+2/4/8** (like in all the other cases). I changed the order of the assignments, so the final **xSP** value will be the correct one popped from the stack, as can be seen in this example:

```
define dso_local %struct.Memory* @sub_0(%struct.State* noalias dereferenceable(3376), i64, %struct.Memory* noalias) local_unnamed_addr #0 {
entry:
  %PC = getelementptr inbounds %struct.State, %struct.State* %0, i64 0, i32 6, i32 33, i32 0, i32 0
  %RSP = getelementptr inbounds %struct.State, %struct.State* %0, i64 0, i32 6, i32 13, i32 0, i32 0
  %3 = add i64 %1, 1
  store i64 %3, i64* %PC, align 8
  ; %4 = RSP value
  %4 = load i64, i64* %RSP, align 8
  ; %call.i.i = popped RSP value
  %call.i.i = tail call i64 @__remill_read_memory_64(%struct.Memory* %2, i64 %4) #3
  ; the popped RSP value is saved on the RSP pointer
  store i64 %call.i.i, i64* %RSP, align 8
  %5 = tail call %struct.Memory* @__remill_missing_block(%struct.State* nonnull %0, i64 %3, %struct.Memory* %2)
  ret %struct.Memory* %5
}
```

I hope I didn't miss any obvious problem of changing the order of the instructions.