### PR TITLE
added tests and instructions for MOVBE_GPRv_MEMv_16/32

### DIFF
--- a/remill/Arch/X86/Semantics/DATAXFER.cpp
+++ b/remill/Arch/X86/Semantics/DATAXFER.cpp
@@ -45,6 +45,15 @@ DEF_SEM(MOVBE32, D dst, const S src) {
   return memory;
 }
 
+
+#if 64 == ADDRESS_SIZE_BITS
+  template <typename D, typename S>
+  DEF_SEM(MOVBE64, D dst, const S src) {
+    Write(dst, __builtin_bswap64(Read(src)));
+    return memory;
+  }
+#endif 
+
 template <typename D, typename S>
 DEF_SEM(MOVQ, D dst, S src) {
   UWriteV64(dst, UExtractV64(UReadV64(src), 0));
@@ -157,6 +166,7 @@ DEF_ISEL_RnW_In(MOV_GPRv_IMMz, MOV);
 DEF_ISEL_MnW_In(MOV_MEMv_IMMz, MOV);
 DEF_ISEL(MOVBE_GPRv_MEMv_16) = MOVBE16<R16W, M16>;
 DEF_ISEL(MOVBE_GPRv_MEMv_32) = MOVBE32<R32W, M32>;
+IF_64BIT(DEF_ISEL(MOVBE_GPRv_MEMv_64) = MOVBE64<R64W, M64>;)
 DEF_ISEL(MOV_GPR8_GPR8_88) = MOV<R8W, R8>;
 DEF_ISEL(MOV_MEMb_GPR8) = MOV<M8W, R8>;
 DEF_ISEL_MnW_Rn(MOV_MEMv_GPRv, MOV);

--- a/remill/Arch/X86/Semantics/DATAXFER.cpp
+++ b/remill/Arch/X86/Semantics/DATAXFER.cpp
@@ -34,6 +34,18 @@ DEF_SEM(XCHG, D1 dst, S1 dst_val, D2 src, S2 src_val) {
 }
 
 template <typename D, typename S>
+DEF_SEM(MOVBE16, D dst, const S src) {
+  WriteZExt(dst, __builtin_bswap16(Read(src)));
+  return memory;
+}
+
+template <typename D, typename S>
+DEF_SEM(MOVBE32, D dst, const S src) {
+  WriteZExt(dst, __builtin_bswap32(Read(src)));
+  return memory;
+}
+
+template <typename D, typename S>
 DEF_SEM(MOVQ, D dst, S src) {
   UWriteV64(dst, UExtractV64(UReadV64(src), 0));
   return memory;
@@ -143,6 +155,8 @@ DEF_ISEL(MOV_GPR8_IMMb_C6r0) = MOV<R8W, I8>;
 DEF_ISEL(MOV_MEMb_IMMb) = MOV<M8W, I8>;
 DEF_ISEL_RnW_In(MOV_GPRv_IMMz, MOV);
 DEF_ISEL_MnW_In(MOV_MEMv_IMMz, MOV);
+DEF_ISEL(MOVBE_GPRv_MEMv_16) = MOVBE16<R16W, M16>;
+DEF_ISEL(MOVBE_GPRv_MEMv_32) = MOVBE32<R32W, M32>;
 DEF_ISEL(MOV_GPR8_GPR8_88) = MOV<R8W, R8>;
 DEF_ISEL(MOV_MEMb_GPR8) = MOV<M8W, R8>;
 DEF_ISEL_MnW_Rn(MOV_MEMv_GPRv, MOV);

--- a/tests/X86/DATAXFER/MOVBE.S
+++ b/tests/X86/DATAXFER/MOVBE.S
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+TEST_BEGIN_64(MOVBE_GPRv_MEMv_16, 1)
+TEST_INPUTS(
+    0)
+    movbe ax, [rsp - 8]
+TEST_END_64
+
+TEST_BEGIN_64(MOVBE_GPRv_MEMv_32, 1)
+TEST_INPUTS(
+    0)
+    movbe eax, [rsp - 8]
+TEST_END_64
+

--- a/tests/X86/DATAXFER/MOVBE.S
+++ b/tests/X86/DATAXFER/MOVBE.S
@@ -14,15 +14,23 @@
  * limitations under the License.
  */
 
-TEST_BEGIN_64(MOVBE_GPRv_MEMv_16, 1)
+TEST_BEGIN_64(MOVBE_GPRv_MEMv_16,  1)
 TEST_INPUTS(
-    0)
-    movbe ax, [rsp - 8]
+    0x41ec)
+    push ARG1_64
+    movbe ax, [rsp]
 TEST_END_64
 
 TEST_BEGIN_64(MOVBE_GPRv_MEMv_32, 1)
 TEST_INPUTS(
-    0)
-    movbe eax, [rsp - 8]
+    0x41ec0806)
+    push ARG1_64
+    movbe eax, [rsp]
 TEST_END_64
 
+TEST_BEGIN_64(MOVBE_GPRv_MEMv_64, 1)
+TEST_INPUTS(
+    0x41ec080600)
+    push ARG1_64
+    movbe rax, [rsp]
+TEST_END_64

--- a/tests/X86/Tests.S
+++ b/tests/X86/Tests.S
@@ -332,6 +332,7 @@ SYMBOL(__x86_test_table_begin):
 #include "tests/X86/DATAXFER/MOV.S"
 #include "tests/X86/DATAXFER/MOVAPD.S"
 #include "tests/X86/DATAXFER/MOVAPS.S"
+#include "tests/X86/DATAXFER/MOVBE.S"
 #include "tests/X86/DATAXFER/MOVD.S"
 #include "tests/X86/DATAXFER/MOVDQA.S"
 #include "tests/X86/DATAXFER/MOVDQU.S"


### PR DESCRIPTION
I know it's implemented slightly unconventionally according to the macros, I'll change that if necessary