### PR TITLE
Support UD0 and UD1 lifting

### DIFF
--- a/remill/Arch/X86/Arch.cpp
+++ b/remill/Arch/X86/Arch.cpp
@@ -165,8 +165,15 @@ static bool IsNoOp(const xed_decoded_inst_t *xedd) {
 }
 
 static bool IsError(const xed_decoded_inst_t *xedd) {
-  auto iclass = xed_decoded_inst_get_iclass(xedd);
-  return XED_ICLASS_HLT == iclass || XED_ICLASS_UD2 == iclass;
+  switch (xed_decoded_inst_get_iclass(xedd)) {
+    case XED_ICLASS_HLT:
+    case XED_ICLASS_UD0:
+    case XED_ICLASS_UD1:
+    case XED_ICLASS_UD2:
+      return true;
+    default:
+      return false;
+  }
 }
 
 static bool IsInvalid(const xed_decoded_inst_t *xedd) {

--- a/remill/Arch/X86/Semantics/MISC.cpp
+++ b/remill/Arch/X86/Semantics/MISC.cpp
@@ -115,6 +115,11 @@ DEF_SEM(DoNothing) {
   return memory;
 }
 
+template<typename S1, typename S2>
+DEF_SEM(DoNothingWithParam, S1 src1, S2 src2) {
+  return memory;
+}
+
 DEF_SEM(DoCLFLUSH_MEMmprefetch, M8) {
   return memory;
 }
@@ -170,6 +175,10 @@ DEF_ISEL(LFENCE) = DoLFENCE;
 DEF_ISEL(XLAT) = DoXLAT;
 
 DEF_ISEL(CPUID) = DoCPUID;
+
+DEF_ISEL(UD0_GPR32_MEMd) = DoNothingWithParam<R32, M32>;
+
+DEF_ISEL(UD1_GPR32_MEMd) = DoNothingWithParam<R32, M32>;
 
 DEF_ISEL(UD2) = DoNothing;
 

--- a/remill/BC/Lifter.cpp
+++ b/remill/BC/Lifter.cpp
@@ -179,11 +179,13 @@ LiftStatus InstructionLifter::LiftIntoBlock(
 
   // Update the current program counter. Control-flow instructions may update
   // the program counter in the semantics code.
-  ir.CreateStore(
-      ir.CreateAdd(
-          ir.CreateLoad(pc_ptr),
-          llvm::ConstantInt::get(word_type, arch_inst.NumBytes())),
-      pc_ptr);
+  if (!arch_inst.IsError()) {
+    ir.CreateStore(
+        ir.CreateAdd(
+            ir.CreateLoad(pc_ptr),
+            llvm::ConstantInt::get(word_type, arch_inst.NumBytes())),
+        pc_ptr);
+  }
 
   // Pass in current value of the memory pointer.
   args[0] = ir.CreateLoad(mem_ptr);


### PR DESCRIPTION
Hello,

This PR supports lifting for `UD0` and `UD1` instructions, e.g.

```asm
0x0        0f ff 01        ud0 eax, [rcx]
0x3        0f b9 27        ud1 esp, [rdi]
```

There is also a change in:

https://github.com/trailofbits/remill/blob/70b14ef3dfd9080229ee91a88218b676486dee28/remill/BC/Lifter.cpp#L180-L186

for which I think the `PC` shouldn't be updated in case of `UDx` or `HLT` because the execution such an instruction would never update `PC`.

Many thanks for responses.