### PR TITLE
Support (partially) far calls

### DIFF
--- a/remill/Arch/Runtime/HyperCall.h
+++ b/remill/Arch/Runtime/HyperCall.h
@@ -87,8 +87,9 @@ class AsyncHyperCall {
     kX86SysEnter,
     kX86SysExit,
 
-    // Far jumps: CS should be updated.
+    // Far jumps/calls: CS should be updated.
     kX86JmpFar,
+    kX86CallFar,
 
     kAArch64SupervisorCall,
 


### PR DESCRIPTION
Hello

This PR is for early review only (my purpose is to support far call/ret in both 64-bit/compat modes). E.g.

```asm
9a 50 04 00 00 33 00        call far 0x33:0x450
```

There as some detail in `remill` for which I'm still confused:

https://github.com/trailofbits/remill/blob/d37ee6bc30b689480d9ef274e3f96fc7d76a190c/remill/Arch/X86/Semantics/CALL_RET.cpp#L21-L28

What is the `_IF_32BIT` macro used in this line?

```cpp
Write(WritePtr<addr_t>(next_sp _IF_32BIT(REG_SS_BASE)), Read(return_pc)); 
```

And a bizzare error, when I try to lift the instruction using:

```bash
remill-lift-7.0 --arch x86 --bytes 9a500400003300 --ir-out /dev/stdout
```
but get

```bash
F0802 19:25:22.794279  3980 Util.cpp:842] Cannot declare internal function _ZN12_GLOBAL__N_112CALL_FAR_PTRI2InIjES1_ItEEEP6MemoryS5_R5StateT_T0_S2_ as external in another module
```

Many thanks for any help.