### PR TITLE
Function metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,7 @@ install(FILES
 
 install(FILES 
   "${CMAKE_CURRENT_SOURCE_DIR}/remill/BC/ABI.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}/remill/BC/Annotate.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/remill/BC/IntrinsicTable.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/remill/BC/Lifter.h"
   "${CMAKE_CURRENT_SOURCE_DIR}/remill/BC/Optimizer.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,16 +106,17 @@ add_library(${PROJECT_NAME} STATIC
   remill/Arch/AArch64/Decode.cpp
   remill/Arch/AArch64/Extract.cpp
   remill/Arch/X86/Arch.cpp
-  
+
   remill/Arch/Arch.cpp
   remill/Arch/Instruction.cpp
   remill/Arch/Name.cpp
 
+  remill/BC/Annotate.cpp
+  remill/BC/DeadStoreEliminator.cpp
   remill/BC/IntrinsicTable.cpp
   remill/BC/Lifter.cpp
-  remill/BC/Util.cpp
-  remill/BC/DeadStoreEliminator.cpp
   remill/BC/Optimizer.cpp
+  remill/BC/Util.cpp
 
   remill/OS/Compat.cpp
   remill/OS/FileSystem.cpp

--- a/remill/BC/Annotate.cpp
+++ b/remill/BC/Annotate.cpp
@@ -16,6 +16,8 @@
 
 #include "Annotate.h"
 
+#include <glog/logging.h>
+
 namespace remill {
 
 const std::string BaseFunction::metadata_value = "base";

--- a/remill/BC/Annotate.cpp
+++ b/remill/BC/Annotate.cpp
@@ -46,6 +46,8 @@ const std::string RemillHelper::metadata_value = Helper::metadata_value + "." +
 const std::string McSemaHelper::metadata_value = Helper::metadata_value + "." +
                                                  "mcsema";
 
+#if LLVM_VERSION_NUMBER >= LLVM_VERSION( 4, 0 )
+
 llvm::MDNode *TieFunction( llvm::Function *first, llvm::Function *second,
                            const std::string& kind ) {
   auto &C = first->getContext();
@@ -79,4 +81,5 @@ llvm::Function *GetTied( llvm::Function *func, const std::string &kind ) {
   return llvm::dyn_cast< llvm::Function >( casted->getValue() );
 }
 
+#endif
 } // namespace remill

--- a/remill/BC/Annotate.cpp
+++ b/remill/BC/Annotate.cpp
@@ -46,39 +46,39 @@ const std::string RemillHelper::metadata_value = Helper::metadata_value + "." +
 const std::string McSemaHelper::metadata_value = Helper::metadata_value + "." +
                                                  "mcsema";
 
-#if LLVM_VERSION_NUMBER >= LLVM_VERSION( 4, 0 )
+#if LLVM_VERSION_NUMBER >= LLVM_VERSION(4, 0)
 
-llvm::MDNode *TieFunction( llvm::Function *first, llvm::Function *second,
-                           const std::string& kind ) {
+llvm::MDNode *TieFunction(llvm::Function *first, llvm::Function *second,
+                           const std::string& kind) {
   auto &C = first->getContext();
-  auto node = llvm::MDNode::get( C, llvm::ConstantAsMetadata::get( second ) );
-  first->setMetadata( kind, node );
+  auto node = llvm::MDNode::get(C, llvm::ConstantAsMetadata::get(second));
+  first->setMetadata(kind, node);
   return node;
 }
 
-std::pair< llvm::MDNode *, llvm::MDNode * >
-TieFunctions( llvm::Function *first, llvm::Function *second, const std::string &kind ) {
-  LOG_IF( FATAL, IsTied( first ) || IsTied( second ) )
+std::pair<llvm::MDNode *, llvm::MDNode *>
+TieFunctions(llvm::Function *first, llvm::Function *second, const std::string &kind) {
+  LOG_IF(FATAL, IsTied(first) || IsTied(second))
       << "Tried to tie already tied functions " << first->getName().str()
-      << " to " << second->getName().str();
+      << " to " <<second->getName().str();
 
-  return { TieFunction( first, second, kind ), TieFunction( second, first, kind ) };
+  return { TieFunction(first, second, kind), TieFunction(second, first, kind) };
 }
 
 
-llvm::Function *GetTied( llvm::Function *func, const std::string &kind ) {
-  auto node = GetTieNode( func, kind );
-  if ( !node || node->getNumOperands() != 1 ) {
+llvm::Function *GetTied(llvm::Function *func, const std::string &kind) {
+  auto node = GetTieNode(func, kind);
+  if (!node || node->getNumOperands() != 1) {
     return nullptr;
   }
 
-  auto casted = llvm::dyn_cast< llvm::ConstantAsMetadata >( node->getOperand( 0 ) );
+  auto casted = llvm::dyn_cast<llvm::ConstantAsMetadata>(node->getOperand(0));
 
   // For now we crash here, since this should not happen
-  LOG_IF( FATAL, !casted )
+  LOG_IF(FATAL, !casted)
       << "Was not able to cast llvm::MDNode to llvm::ConstantAsMetadata, possible error.";
 
-  return llvm::dyn_cast< llvm::Function >( casted->getValue() );
+  return llvm::dyn_cast<llvm::Function>(casted->getValue());
 }
 
 #endif

--- a/remill/BC/Annotate.cpp
+++ b/remill/BC/Annotate.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Annotate.h"
+
+namespace remill {
+
+const std::string BaseFunction::metadata_value = "base";
+
+const std::string BaseFunction::metadata_kind = "remill.function.type";
+
+const std::string LiftedFunction::metadata_value = BaseFunction::metadata_value + "." + "lifted";
+
+const std::string EntrypointFunction::metadata_value = BaseFunction::metadata_value + "." +
+                                                       "entrypoint";
+
+const std::string ExternalFunction::metadata_value = BaseFunction::metadata_value + "." +
+                                                     "external";
+
+
+const std::string Helper::metadata_value = BaseFunction::metadata_value + "." + "helper";
+
+
+const std::string RemillHelper::metadata_value = Helper::metadata_value + "." +
+                                                  "remill";
+
+const std::string McSemaHelper::metadata_value = Helper::metadata_value + "." +
+                                                 "mcsema";
+} // namespace remill

--- a/remill/BC/Annotate.cpp
+++ b/remill/BC/Annotate.cpp
@@ -46,12 +46,12 @@ const std::string RemillHelper::metadata_value = Helper::metadata_value + "." +
 const std::string McSemaHelper::metadata_value = Helper::metadata_value + "." +
                                                  "mcsema";
 
-llvm::MDNode *TieNode( llvm::Function *func, const std::string &kind ) {
+llvm::MDNode *GetTieNode( llvm::Function *func, const std::string &kind ) {
   return func->getMetadata( kind );
 }
 
 bool IsTied( llvm::Function *func, const std::string& kind ) {
-  return TieNode( func, kind );
+  return GetTieNode( func, kind );
 }
 
 llvm::MDNode *TieFunction( llvm::Function *first, llvm::Function *second,
@@ -73,7 +73,7 @@ TieFunctions( llvm::Function *first, llvm::Function *second, const std::string &
 
 
 llvm::Function *GetTied( llvm::Function *func, const std::string &kind ) {
-  auto node = TieNode( func, kind );
+  auto node = GetTieNode( func, kind );
   if ( !node || node->getNumOperands() != 1 ) {
     return nullptr;
   }

--- a/remill/BC/Annotate.cpp
+++ b/remill/BC/Annotate.cpp
@@ -30,6 +30,12 @@ const std::string EntrypointFunction::metadata_value = BaseFunction::metadata_va
 const std::string ExternalFunction::metadata_value = BaseFunction::metadata_value + "." +
                                                      "external";
 
+const std::string AbiLibraries::metadata_value = ExternalFunction::metadata_value + "." +
+                                                 "abilibraries";
+
+const std::string CFGExternal::metadata_value = ExternalFunction::metadata_value + "." +
+                                                "cfgexternal";
+
 
 const std::string Helper::metadata_value = BaseFunction::metadata_value + "." + "helper";
 
@@ -39,4 +45,5 @@ const std::string RemillHelper::metadata_value = Helper::metadata_value + "." +
 
 const std::string McSemaHelper::metadata_value = Helper::metadata_value + "." +
                                                  "mcsema";
+
 } // namespace remill

--- a/remill/BC/Annotate.cpp
+++ b/remill/BC/Annotate.cpp
@@ -16,8 +16,6 @@
 
 #include "Annotate.h"
 
-#include <glog/logging.h>
-
 namespace remill {
 
 const std::string BaseFunction::metadata_value = "base";
@@ -47,7 +45,6 @@ const std::string RemillHelper::metadata_value = Helper::metadata_value + "." +
 
 const std::string McSemaHelper::metadata_value = Helper::metadata_value + "." +
                                                  "mcsema";
-
 
 llvm::MDNode *TieNode( llvm::Function *func, const std::string &kind ) {
   return func->getMetadata( kind );

--- a/remill/BC/Annotate.cpp
+++ b/remill/BC/Annotate.cpp
@@ -74,9 +74,10 @@ llvm::Function *GetTied(llvm::Function *func, const std::string &kind) {
 
   auto casted = llvm::dyn_cast<llvm::ConstantAsMetadata>(node->getOperand(0));
 
-  // For now we crash here, since this should not happen
-  LOG_IF(FATAL, !casted)
-      << "Was not able to cast llvm::MDNode to llvm::ConstantAsMetadata, possible error.";
+  if (!casted) {
+    DLOG(INFO) << func->getName().str() << " with kind " << kind << " was tied to nullptr";
+    return nullptr;
+  }
 
   return llvm::dyn_cast<llvm::Function>(casted->getValue());
 }

--- a/remill/BC/Annotate.cpp
+++ b/remill/BC/Annotate.cpp
@@ -46,14 +46,6 @@ const std::string RemillHelper::metadata_value = Helper::metadata_value + "." +
 const std::string McSemaHelper::metadata_value = Helper::metadata_value + "." +
                                                  "mcsema";
 
-llvm::MDNode *GetTieNode( llvm::Function *func, const std::string &kind ) {
-  return func->getMetadata( kind );
-}
-
-bool IsTied( llvm::Function *func, const std::string& kind ) {
-  return GetTieNode( func, kind );
-}
-
 llvm::MDNode *TieFunction( llvm::Function *first, llvm::Function *second,
                            const std::string& kind ) {
   auto &C = first->getContext();

--- a/remill/BC/Annotate.h
+++ b/remill/BC/Annotate.h
@@ -375,6 +375,8 @@ static inline std::unordered_map< llvm::Function *, llvm::Function * > GetTieMap
   return {};
 }
 
+#undef NOT_AVAILABLE
+
 #endif
 
 

--- a/remill/BC/Annotate.h
+++ b/remill/BC/Annotate.h
@@ -16,12 +16,9 @@
 
 #pragma once
 
-#include <glog/logging.h>
-
 #include <string>
 #include <utility>
 #include <vector>
-
 
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Metadata.h>

--- a/remill/BC/Annotate.h
+++ b/remill/BC/Annotate.h
@@ -65,6 +65,11 @@ const std::string TieKind = "remill.function.tie";
 
 // Note(Aiethel): I tried to make them static methods and while it works it is not really worth
 
+// Versions before LLVM-4.0 do not have metadata for functions. There is (probably) no reasonable way
+// to simulate them, therefore older version do not provide this functionality. However, since these
+// annotations are not crucial to lift itself, definition of functions are provided (so that project)
+// compiles. They issue error and return negative answers and nullptrs.
+
 #if LLVM_VERSION_NUMBER >= LLVM_VERSION(4, 0)
 template< typename OriginType >
 bool Contains( llvm::MDString *node ) {

--- a/remill/BC/Annotate.h
+++ b/remill/BC/Annotate.h
@@ -71,12 +71,12 @@ const std::string TieKind = "remill.function.tie";
 #if LLVM_VERSION_NUMBER >= LLVM_VERSION(4, 0)
 
 template<typename OriginType>
-bool Contains(llvm::MDString *node) {
+static bool Contains(llvm::MDString *node) {
   return node && node->getString().contains(OriginType::metadata_value);
 }
 
 template<typename OriginType>
-llvm::MDNode *GetNode(llvm::Function *func) {
+static llvm::MDNode *GetNode(llvm::Function *func) {
 
   auto metadata_node = func->getMetadata(OriginType::metadata_kind);
 
@@ -90,7 +90,7 @@ llvm::MDNode *GetNode(llvm::Function *func) {
 }
 
 template<typename OriginType>
-bool Remove(llvm::Function *func) {
+static bool Remove(llvm::Function *func) {
   auto node = GetNode<OriginType>(func);
   if (!node) {
     return false;
@@ -102,7 +102,7 @@ bool Remove(llvm::Function *func) {
 
 // Give function OriginType
 template<typename OriginType>
-void Annotate(llvm::Function *func) {
+static void Annotate(llvm::Function *func) {
   auto &C = func->getContext();
   DLOG(INFO) << "Annotating: " << func->getName().str() << ": " << OriginType::metadata_kind
              << " -> " << OriginType::metadata_value;
@@ -111,18 +111,18 @@ void Annotate(llvm::Function *func) {
 }
 
 template<typename OriginType>
-bool HasOriginType(llvm::Function *func) {
+static bool HasOriginType(llvm::Function *func) {
   return GetNode<OriginType>(func);
 }
 
 template<typename Type, typename Second, typename ...OriginTypes>
-bool HasOriginType(llvm::Function *func) {
+static bool HasOriginType(llvm::Function *func) {
   return HasOriginType<Type>(func) || HasOriginType<Second, OriginTypes...>(func);
 }
 
 // Return list of functions that are one of chosen OriginType
 template<typename Container, typename ... OriginTypes>
-void GetFunctionsByOrigin(llvm::Module &module, Container &result) {
+static void GetFunctionsByOrigin(llvm::Module &module, Container &result) {
   for (auto& func : module) {
     if (HasOriginType<OriginTypes...>(&func)) {
       // Method that is both in std::set and std::vector
@@ -132,19 +132,19 @@ void GetFunctionsByOrigin(llvm::Module &module, Container &result) {
 }
 
 template<typename Container, typename ... OriginTypes>
-Container GetFunctionsByOrigin(llvm::Module &module) {
+static Container GetFunctionsByOrigin(llvm::Module &module) {
   Container result;
   GetFunctionsByOrigin<Container, OriginTypes...>(module, result);
   return result;
 }
 
 template<typename OriginType>
-void ChangeOriginType(llvm::Function *func) {
+static void ChangeOriginType(llvm::Function *func) {
   Annotate<OriginType>(func);
 }
 
 template<typename OriginType, typename OldType>
-bool ChangeOriginType(llvm::Function *func) {
+static bool ChangeOriginType(llvm::Function *func) {
   if (HasOriginType<OldType>(func)) {
     ChangeOriginType<OriginType>(func);
     return true;
@@ -180,7 +180,7 @@ llvm::Function *GetTied(llvm::Function *func, const std::string &kind = TieKind)
  * required.
  */
 template<typename BinaryPredicate>
-void GetTieMapping(
+static void GetTieMapping(
     llvm::Module &module,
     BinaryPredicate pred,
     std::unordered_map<llvm::Function *, llvm::Function *> &result,
@@ -196,7 +196,7 @@ void GetTieMapping(
 
 // TODO(C++14): Deduced return types
 template<typename BinaryPredicate, typename Container>
-std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
+static std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
     llvm::Module &module,
     BinaryPredicate pred,
     const Container &kinds) {
@@ -211,8 +211,8 @@ std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
 // TODO(C++14): Deduced return types
 // If functions are annotated with OriginTypes, this overload filters based on these annotations.
 template<typename FromType, typename ToType = BaseFunction,
-          typename Container = std::vector<std::string>>
-std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
+         typename Container = std::vector<std::string>>
+static std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
     llvm::Module &module,
     const Container &kinds) {
 
@@ -224,7 +224,7 @@ std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
 
 // TODO(C++14): Deduced return types
 template<typename FromType, typename ToType = BaseFunction>
-std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
+static std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
     llvm::Module &module,
     const std::string &kind = TieKind) {
 
@@ -248,59 +248,59 @@ static inline std::unordered_map<llvm::Function *, llvm::Function *> GetTieMappi
   LOG(Err) <<"LLVM version is less than 4.0, functions metadata are not avalaible"
 
 template<typename OriginType>
-bool Contains(llvm::MDString *node) {
+static bool Contains(llvm::MDString *node) {
   NOT_AVAILABLE(ERROR);
   return false;
 }
 
 template<typename OriginType>
-llvm::MDNode *GetNode(llvm::Function *func) {
+static llvm::MDNode *GetNode(llvm::Function *func) {
   NOT_AVAILABLE(ERROR);
   return nullptr;
 }
 
 template<typename OriginType>
-bool Remove(llvm::Function *func) {
+static bool Remove(llvm::Function *func) {
   NOT_AVAILABLE(ERROR);
   return false;
 }
 
 // Give function OriginType
 template<typename OriginType>
-void Annotate(llvm::Function *func ) {
+static void Annotate(llvm::Function *func ) {
   NOT_AVAILABLE(ERROR);
 }
 
 template<typename OriginType>
-bool HasOriginType(llvm::Function *func) {
+static bool HasOriginType(llvm::Function *func) {
   NOT_AVAILABLE(ERROR);
   return false;
 }
 
 template<typename Type, typename Second, typename ...OriginTypes>
-bool HasOriginType(llvm::Function *func) {
+static bool HasOriginType(llvm::Function *func) {
   NOT_AVAILABLE(ERROR);
   return false;
 }
 
 template<typename Container, typename ... OriginTypes>
-void GetFunctionsByOrigin(llvm::Module &module, Container &result) {
+static void GetFunctionsByOrigin(llvm::Module &module, Container &result) {
   NOT_AVAILABLE(ERROR);
 }
 
 template<typename Container, typename ... OriginTypes>
-Container GetFunctionsByOrigin(llvm::Module &module) {
+static Container GetFunctionsByOrigin(llvm::Module &module) {
   NOT_AVAILABLE(ERROR);
   return {};
 }
 
 template<typename OriginType>
-void ChangeOriginType(llvm::Function *func) {
+static void ChangeOriginType(llvm::Function *func) {
   NOT_AVAILABLE(ERROR);
 }
 
 template<typename OriginType, typename OldType>
-bool ChangeOriginType(llvm::Function *func) {
+static bool ChangeOriginType(llvm::Function *func) {
   NOT_AVAILABLE(ERROR);
   return false;
 }
@@ -333,7 +333,7 @@ static inline llvm::Function *GetTied(llvm::Function *func, const std::string &k
 }
 
 template<typename BinaryPredicate>
-void GetTieMapping(
+static void GetTieMapping(
     llvm::Module &module,
     BinaryPredicate pred,
     std::unordered_map<llvm::Function *, llvm::Function *> &result,
@@ -342,7 +342,7 @@ void GetTieMapping(
 }
 
 template<typename BinaryPredicate, typename Container>
-std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
+static std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
     llvm::Module &module,
     BinaryPredicate pred,
     const Container &kinds) {
@@ -352,7 +352,7 @@ std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
 
 template<typename FromType, typename ToType = BaseFunction,
           typename Container = std::vector<std::string>>
-std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
+static std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
     llvm::Module &module,
     const Container &kinds) {
   NOT_AVAILABLE(ERROR);
@@ -360,7 +360,7 @@ std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
 }
 
 template<typename FromType, typename ToType = BaseFunction>
-std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
+static std::unordered_map<llvm::Function *, llvm::Function *> GetTieMapping(
     llvm::Module &module,
     const std::string &kind = TieKind) {
   NOT_AVAILABLE(ERROR);

--- a/remill/BC/Annotate.h
+++ b/remill/BC/Annotate.h
@@ -104,8 +104,8 @@ bool Remove(llvm::Function *func) {
 template<typename OriginType>
 void Annotate(llvm::Function *func) {
   auto &C = func->getContext();
-  LOG(INFO) << "Annotating: " << func->getName().str() << ": " << OriginType::metadata_kind
-            << " -> " << OriginType::metadata_value << std::endl;
+  DLOG(INFO) << "Annotating: " << func->getName().str() << ": " << OriginType::metadata_kind
+             << " -> " << OriginType::metadata_value;
   auto node = llvm::MDNode::get(C, llvm::MDString::get(C, OriginType::metadata_value));
   func->setMetadata(OriginType::metadata_kind, node);
 }

--- a/remill/BC/Annotate.h
+++ b/remill/BC/Annotate.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -150,9 +151,13 @@ bool ChangeOriginType( llvm::Function *func ) {
 const std::string TieKind = "remill.function.tie";
 
 // Get node that is holding the tie information
-llvm::MDNode *GetTieNode( llvm::Function *func, const std::string &kind = TieKind );
+static inline llvm::MDNode *GetTieNode( llvm::Function *func, const std::string &kind = TieKind ) {
+  return func->getMetadata( kind );
+}
 
-bool IsTied( llvm::Function *func, const std::string& kind = TieKind );
+static inline bool IsTied( llvm::Function *func, const std::string& kind = TieKind ) {
+  return GetTieNode( func, kind );
+}
 
 // Add metadata to first with information about second
 llvm::MDNode *TieFunction( llvm::Function *first, llvm::Function *second,

--- a/remill/BC/Annotate.h
+++ b/remill/BC/Annotate.h
@@ -45,6 +45,8 @@ struct children : parent { \
 DECLARE_FUNC_ORIGIN_TYPE( LiftedFunction, BaseFunction );
 DECLARE_FUNC_ORIGIN_TYPE( EntrypointFunction, BaseFunction );
 DECLARE_FUNC_ORIGIN_TYPE( ExternalFunction, BaseFunction );
+DECLARE_FUNC_ORIGIN_TYPE( AbiLibraries, ExternalFunction );
+DECLARE_FUNC_ORIGIN_TYPE( CFGExternal, ExternalFunction );
 DECLARE_FUNC_ORIGIN_TYPE( Helper, BaseFunction );
 DECLARE_FUNC_ORIGIN_TYPE( RemillHelper, Helper );
 DECLARE_FUNC_ORIGIN_TYPE( McSemaHelper, Helper );
@@ -78,6 +80,12 @@ Container GetFunctionsByOrigin( llvm::Module &module, const Kind & ) {
     }
   }
   return result;
+}
+
+// Return list of functions that are of chosen kind
+template< typename Kind, typename Container = std::vector< llvm::Function * > >
+Container GetFunctionsByOrigin( llvm::Module &module ) {
+  return GetFunctionsByOrigin( module, Kind{} );
 }
 
 } // namespace remill

--- a/remill/BC/Annotate.h
+++ b/remill/BC/Annotate.h
@@ -16,8 +16,12 @@
 
 #pragma once
 
+#include <glog/logging.h>
+
 #include <string>
+#include <utility>
 #include <vector>
+
 
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Metadata.h>
@@ -87,5 +91,30 @@ template< typename Kind, typename Container = std::vector< llvm::Function * > >
 Container GetFunctionsByOrigin( llvm::Module &module ) {
   return GetFunctionsByOrigin( module, Kind{} );
 }
+
+/* Functions that "tie" together two functions via specific metada:
+ * Both of them will contain metadata of specified kind, that is the other function.
+ * This is useful for example to tie entrypoints and their corresponding sub_ functions
+ */
+
+
+// Default kind to be used, user is free to choose different, for example if each function
+// is supposed to be part of multiple pairs
+const std::string TieKind = "remill.function.tie";
+
+// Get node that is holding the tie information
+llvm::MDNode *TieNode( llvm::Function *func, const std::string &kind = TieKind );
+
+bool IsTied( llvm::Function *func, const std::string& kind = TieKind );
+
+// Add metadata to first with information about second
+llvm::MDNode *TieFunction( llvm::Function *first, llvm::Function *second,
+                           const std::string& kind = TieKind );
+
+std::pair< llvm::MDNode *, llvm::MDNode * >
+TieFunctions( llvm::Function *first, llvm::Function *second, const std::string &kind = TieKind );
+
+// Get function that is tied to func, or nullptr if there is no such function
+llvm::Function *GetTied( llvm::Function *func, const std::string &kind = TieKind );
 
 } // namespace remill

--- a/remill/BC/Annotate.h
+++ b/remill/BC/Annotate.h
@@ -108,18 +108,21 @@ bool HasOriginType( llvm::Function *func ) {
   return HasOriginType< Type >( func ) || HasOriginType< Second, OriginTypes... >( func );
 }
 
-// Return list of functions that are of chosen OriginType
-template< typename OriginType, typename Container = std::vector< llvm::Function * > >
-Container GetFunctionsByOrigin( llvm::Module &module ) {
-
-  Container result;
-
-  for ( auto &func : module ) {
-    if ( HasOriginType< OriginType >( &func ) ) {
+// Return list of functions that are one of chosen OriginType
+template< typename Container, typename ... OriginTypes >
+void GetFunctionsByOrigin( llvm::Module &module, Container &result ) {
+  for ( auto& func : module ) {
+    if ( HasOriginType< OriginTypes... >( &func ) ) {
       // Method that is both in std::set and std::vector
       result.insert( result.end(), &func );
     }
   }
+}
+
+template< typename Container, typename ... OriginTypes >
+Container GetFunctionsByOrigin( llvm::Module &module ) {
+  Container result;
+  GetFunctionsByOrigin< Container, OriginTypes...>( module, result );
   return result;
 }
 
@@ -147,7 +150,7 @@ bool ChangeOriginType( llvm::Function *func ) {
 const std::string TieKind = "remill.function.tie";
 
 // Get node that is holding the tie information
-llvm::MDNode *TieNode( llvm::Function *func, const std::string &kind = TieKind );
+llvm::MDNode *GetTieNode( llvm::Function *func, const std::string &kind = TieKind );
 
 bool IsTied( llvm::Function *func, const std::string& kind = TieKind );
 

--- a/remill/BC/Annotate.h
+++ b/remill/BC/Annotate.h
@@ -93,6 +93,8 @@ DECLARE_FUNC_ORIGIN_TYPE( Helper, BaseFunction );
 DECLARE_FUNC_ORIGIN_TYPE( RemillHelper, Helper );
 DECLARE_FUNC_ORIGIN_TYPE( McSemaHelper, Helper );
 
+#undef DECLARE_FUNC_ORIGIN_TYPE
+
 template< typename OriginType >
 void Annotate( llvm::Function *func ) {
   return OriginType::Annotate( func );

--- a/remill/BC/Annotate.h
+++ b/remill/BC/Annotate.h
@@ -24,6 +24,8 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/Metadata.h>
 
+#include "remill/BC/Version.h"
+
 #include <glog/logging.h>
 
 namespace remill {
@@ -57,8 +59,13 @@ DECLARE_FUNC_ORIGIN_TYPE( McSemaHelper, Helper );
 
 #undef DECLARE_FUNC_ORIGIN_TYPE
 
+// Default kind to be used, user is free to choose different, for example if each function
+// is supposed to be part of multiple pairs
+const std::string TieKind = "remill.function.tie";
+
 // Note(Aiethel): I tried to make them static methods and while it works it is not really worth
 
+#if LLVM_VERSION_NUMBER >= LLVM_VERSION(4, 0)
 template< typename OriginType >
 bool Contains( llvm::MDString *node ) {
   return node && node->getString().contains( OriginType::metadata_value );
@@ -145,11 +152,6 @@ bool ChangeOriginType( llvm::Function *func ) {
  * This is useful for example to tie entrypoints and their corresponding sub_ functions
  */
 
-
-// Default kind to be used, user is free to choose different, for example if each function
-// is supposed to be part of multiple pairs
-const std::string TieKind = "remill.function.tie";
-
 // Get node that is holding the tie information
 static inline llvm::MDNode *GetTieNode( llvm::Function *func, const std::string &kind = TieKind ) {
   return func->getMetadata( kind );
@@ -235,5 +237,140 @@ static inline std::unordered_map< llvm::Function *, llvm::Function * > GetTieMap
       []( llvm::Function *, llvm::Function * ) { return true; },
       std::vector< std::string >{ kind } );
 }
+
+#else
+
+#define NOT_AVAILABLE(Err) \
+  LOG( Err ) << "LLVM version is less than 4.0, functions metadata are not avalaible"
+
+template< typename OriginType >
+bool Contains( llvm::MDString *node ) {
+  NOT_AVAILABLE( ERROR );
+  return false;
+}
+
+template< typename OriginType >
+llvm::MDNode *GetNode( llvm::Function *func ) {
+  NOT_AVAILABLE( ERROR );
+  return nullptr;
+}
+
+template< typename OriginType >
+bool Remove( llvm::Function *func ) {
+  NOT_AVAILABLE( ERROR );
+  return false;
+}
+
+// Give function OriginType
+template< typename OriginType >
+void Annotate( llvm::Function *func  ) {
+  NOT_AVAILABLE( ERROR );
+}
+
+template< typename OriginType >
+bool HasOriginType( llvm::Function *func ) {
+  NOT_AVAILABLE( ERROR );
+  return false;
+}
+
+template< typename Type, typename Second, typename ...OriginTypes >
+bool HasOriginType( llvm::Function *func ) {
+  NOT_AVAILABLE( ERROR );
+  return false;
+}
+
+template< typename Container, typename ... OriginTypes >
+void GetFunctionsByOrigin( llvm::Module &module, Container &result ) {
+  NOT_AVAILABLE( ERROR );
+}
+
+template< typename Container, typename ... OriginTypes >
+Container GetFunctionsByOrigin( llvm::Module &module ) {
+  NOT_AVAILABLE( ERROR );
+  return {};
+}
+
+template< typename OriginType >
+void ChangeOriginType( llvm::Function *func ) {
+  NOT_AVAILABLE( ERROR );
+}
+
+template< typename OriginType, typename OldType >
+bool ChangeOriginType( llvm::Function *func ) {
+  NOT_AVAILABLE( ERROR );
+  return false;
+}
+
+static inline llvm::MDNode *GetTieNode( llvm::Function *func, const std::string &kind = TieKind ) {
+  NOT_AVAILABLE( ERROR );
+  return nullptr;
+}
+
+static inline bool IsTied( llvm::Function *func, const std::string& kind = TieKind ) {
+  NOT_AVAILABLE( ERROR );
+  return false;
+}
+
+static inline llvm::MDNode *TieFunction( llvm::Function *first, llvm::Function *second,
+                           const std::string& kind = TieKind ) {
+  NOT_AVAILABLE( ERROR );
+  return nullptr;
+}
+
+static inline std::pair< llvm::MDNode *, llvm::MDNode * >
+TieFunctions( llvm::Function *first, llvm::Function *second, const std::string &kind = TieKind ) {
+  NOT_AVAILABLE( ERROR );
+  return {};
+}
+
+static inline llvm::Function *GetTied( llvm::Function *func, const std::string &kind = TieKind ) {
+  NOT_AVAILABLE( ERROR );
+  return nullptr;
+}
+
+template< typename BinaryPredicate >
+void GetTieMapping(
+    llvm::Module &module,
+    BinaryPredicate pred,
+    std::unordered_map< llvm::Function *, llvm::Function * > &result,
+    const std::string &kind = TieKind ) {
+  NOT_AVAILABLE( ERROR );
+}
+
+template< typename BinaryPredicate, typename Container >
+std::unordered_map< llvm::Function *, llvm::Function *> GetTieMapping(
+    llvm::Module &module,
+    BinaryPredicate pred,
+    const Container &kinds ) {
+  NOT_AVAILABLE( ERROR );
+  return {};
+}
+
+template< typename FromType, typename ToType = BaseFunction,
+          typename Container = std::vector< std::string > >
+std::unordered_map< llvm::Function *, llvm::Function *> GetTieMapping(
+    llvm::Module &module,
+    const Container &kinds ) {
+  NOT_AVAILABLE( ERROR );
+  return {};
+}
+
+template< typename FromType, typename ToType = BaseFunction >
+std::unordered_map< llvm::Function *, llvm::Function *> GetTieMapping(
+    llvm::Module &module,
+    const std::string &kind = TieKind ) {
+  NOT_AVAILABLE( ERROR );
+  return {};
+}
+
+static inline std::unordered_map< llvm::Function *, llvm::Function * > GetTieMapping(
+    llvm::Module &module,
+    const std::string &kind = TieKind ) {
+  NOT_AVAILABLE( ERROR );
+  return {};
+}
+
+#endif
+
 
 } // namespace remill

--- a/remill/BC/Annotate.h
+++ b/remill/BC/Annotate.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Metadata.h>
+
+namespace remill {
+
+// For all function holds that Kind should have two static strings
+// * metadata_kind that is the identifier of metadata
+// * metadata_value that is the value that identifies the Kind itself
+
+
+struct BaseFunction {
+  static const std::string metadata_kind;
+  // Each class that inherits from some parent class appends its own metadata_value string with dot
+  // to the parents one, therefore it is possible for search to easily include all subclasses as well
+  static const std::string metadata_value;
+};
+
+// Unfortunately we must define the values of static vars in .cpp file
+#define DECLARE_FUNC_ORIGIN_TYPE(children, parent) \
+struct children : parent { \
+  static const std::string metadata_value; \
+}
+
+DECLARE_FUNC_ORIGIN_TYPE( LiftedFunction, BaseFunction );
+DECLARE_FUNC_ORIGIN_TYPE( EntrypointFunction, BaseFunction );
+DECLARE_FUNC_ORIGIN_TYPE( ExternalFunction, BaseFunction );
+DECLARE_FUNC_ORIGIN_TYPE( Helper, BaseFunction );
+DECLARE_FUNC_ORIGIN_TYPE( RemillHelper, Helper );
+DECLARE_FUNC_ORIGIN_TYPE( McSemaHelper, Helper );
+
+// Give function Kind
+template< typename Kind >
+void Annotate( llvm::Function *func ) {
+  auto &C = func->getContext();
+  auto node = llvm::MDNode::get( C, llvm::MDString::get( C, LiftedFunction::metadata_value ) );
+  func->setMetadata( LiftedFunction::metadata_kind, node );
+}
+
+// Return list of functions that are of chosen kind
+template< typename Kind, typename Container = std::vector< llvm::Function * > >
+Container GetFunctionsByOrigin( llvm::Module &module, const Kind & ) {
+
+  Container result;
+
+  for ( auto &func : module ) {
+
+    auto metadata_node = func.getMetadata( Kind::metadata_kind );
+    // There should be exactly one string there
+    if ( !metadata_node || metadata_node->getNumOperands() != 1 ) {
+      continue;
+    }
+
+    if ( auto message = llvm::dyn_cast< llvm::MDString >( metadata_node->getOperand( 0 ) ) ) {
+      if ( message->getString().contains( Kind::metadata_value ) ) {
+        result.insert( result.end(), &func );
+      }
+    }
+  }
+  return result;
+}
+
+} // namespace remill


### PR DESCRIPTION
Functions can now hold metadata. This PR introduces two main types:
  - `OriginType` specifies why did the function end up in the bitcode. Is it lifted subroutine, entrypoint or remill/mcsema runtime helper?
  - Functions can be "tied" together. Both will contain metadata of the same kind, that holds `llvm::Function *` of other. Useful for example to denote entrypoint <-> lifted subroutine relationship.

Overall these are to help future users/developers who need to filter only some functions in the bitcode. This is currently implemented with some type/string matching and feels odd at best.

Unfortunately LLVM version older than `4.0` do not provide enough API around `Metadata` to implement these functionalities.

 